### PR TITLE
文節区切り変更時の状態管理が間違っていたので治した。

### DIFF
--- a/ibus-akaza/src/context.rs
+++ b/ibus-akaza/src/context.rs
@@ -617,7 +617,6 @@ impl AkazaContext {
     pub fn extend_clause_right(&mut self, engine: *mut IBusEngine) -> Result<()> {
         self.current_state.extend_right();
         self._update_candidates(engine)?;
-        self.current_state.clear_state();
         Ok(())
     }
 
@@ -625,7 +624,6 @@ impl AkazaContext {
     pub fn extend_clause_left(&mut self, engine: *mut IBusEngine) -> Result<()> {
         self.current_state.extend_left();
         self._update_candidates(engine)?;
-        self.current_state.clear_state();
         Ok(())
     }
 

--- a/ibus-akaza/src/current_state.rs
+++ b/ibus-akaza/src/current_state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
-use log::info;
+
 
 use libakaza::extend_clause::{extend_left, extend_right};
 use libakaza::graph::candidate::Candidate;

--- a/ibus-akaza/src/current_state.rs
+++ b/ibus-akaza/src/current_state.rs
@@ -1,8 +1,6 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
-
-
 use libakaza::extend_clause::{extend_left, extend_right};
 use libakaza::graph::candidate::Candidate;
 

--- a/ibus-akaza/src/current_state.rs
+++ b/ibus-akaza/src/current_state.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::ops::Range;
 
+use log::info;
+
 use libakaza::extend_clause::{extend_left, extend_right};
 use libakaza::graph::candidate::Candidate;
 
@@ -67,6 +69,7 @@ impl CurrentState {
 
     pub fn set_clauses(&mut self, clause: Vec<Vec<Candidate>>) {
         self.clauses = clause;
+        self.node_selected.clear();
     }
 
     /// 変換しているときに backspace を入力した場合。
@@ -85,7 +88,7 @@ impl CurrentState {
         targets
     }
 
-    /// 一顧右の文節を選択する
+    /// 一個右の文節を選択する
     pub fn select_right_clause(&mut self) {
         if self.current_clause == self.clauses.len() - 1 {
             // 既に一番右だった場合、一番左にいく。
@@ -95,7 +98,7 @@ impl CurrentState {
         }
     }
 
-    /// 一顧左の文節を選択する
+    /// 一個左の文節を選択する
     pub fn select_left_clause(&mut self) {
         if self.current_clause == 0 {
             // 既に一番左だった場合、一番右にいく

--- a/libakaza/src/extend_clause.rs
+++ b/libakaza/src/extend_clause.rs
@@ -1,3 +1,4 @@
+use log::info;
 use std::ops::Range;
 
 use crate::graph::candidate::Candidate;
@@ -21,7 +22,13 @@ pub fn extend_right(clauses: &Vec<Vec<Candidate>>, current_clause: usize) -> Vec
         return Vec::new();
     }
     // 一番右の文節が選択されていたらなにもできない。
+    info!(
+        "Keep current? current={:?} len={}",
+        current_clause,
+        clauses.len()
+    );
     if current_clause == clauses.len() - 1 {
+        info!("Keep current");
         return keep_current(clauses);
     }
 
@@ -192,6 +199,15 @@ mod tests_right {
         let (yomi, clauses) = mk(&["わ", "たし"]);
         let got = extend_right(&clauses, 0);
         assert_eq!(to_vec(yomi, got), vec!("わた", "し"));
+    }
+
+    // ちゃんと伸ばせるケース
+    #[test]
+    fn test_extend_right4() {
+        let (yomi, clauses) = mk(&["あい", "ですね"]);
+        // 「ですね」にフォーカス。
+        let got = extend_right(&clauses, 1);
+        assert_eq!(to_vec(yomi, got), vec!("あい", "ですね"));
     }
 }
 


### PR DESCRIPTION
exted_clause_right のときに current_state.clear_state() を呼ぶのは誤り。
self.force_selected_clause と self.current_clause はクリアしてはいけない。 self.node_selected はクリアする必要があるが、これは set_clause
のタイミングで自動的に消されるべきなので、一緒に消えるようにした。