### PR TITLE
Config のデフォルトバリューを serde からひろう。

### DIFF
--- a/libakaza/src/config.rs
+++ b/libakaza/src/config.rs
@@ -84,7 +84,9 @@ impl Config {
                     configfile.to_string_lossy(),
                     err
                 );
-                return Ok(Config::default());
+                let config: Config = serde_yaml::from_str("").unwrap();
+                info!("Loaded default configuration: {:?}", config);
+                return Ok(config);
             }
         };
         info!(


### PR DESCRIPTION
`Config::default()` からひろうと、serde の default 設定が
適用されない。

Close #245