### PR TITLE
change keyboard layout to "default"

### DIFF
--- a/ibus-akaza/akaza.xml.in
+++ b/ibus-akaza/akaza.xml.in
@@ -19,7 +19,7 @@
             <author>Tokuhiro Matsuno &lt;tokuhirom@gmail.com&gt;</author>
             <icon>@DATADIR@/ibus-akaza/akaza.svg</icon>
             <icon_prop_key>InputMode</icon_prop_key>
-            <layout>us</layout>
+            <layout>default</layout>
             <layout_variant></layout_variant>
             <layout_option></layout_option>
             <hotkeys></hotkeys>


### PR DESCRIPTION
`akaza.xml` でのkeyboard layoutの指定が `us` になっていたので `default` に変更します。

関連PR: #270 