### PR TITLE
Fix rustfmt formatting issues

### DIFF
--- a/akaza-data/src/subcmd/learn_corpus.rs
+++ b/akaza-data/src/subcmd/learn_corpus.rs
@@ -213,19 +213,16 @@ impl LearningService {
             // Unknown word_id が一種類出ます。が、なぜ出るのか不明。
             // 一個ぐらいのデータがロストしてもここでは問題がないので後回し。
 
-            let Some(word1) = src_wordid2key
-                .get(&word_id1) else {
+            let Some(word1) = src_wordid2key.get(&word_id1) else {
                 info!("Unknown word_id: {}", word_id1);
                 continue;
             };
-            let Some((new_word_id1, _)) = new_unigram
-                .find(word1) else {
+            let Some((new_word_id1, _)) = new_unigram.find(word1) else {
                 info!("Unknown word: {}", word1);
                 continue;
             };
 
-            let Some(word2) = src_wordid2key
-                .get(&word_id2) else {
+            let Some(word2) = src_wordid2key.get(&word_id2) else {
                 info!("Unknown word_id: {}", word_id2);
                 continue;
             };

--- a/libakaza/src/dict/skk/ari2nasi.rs
+++ b/libakaza/src/dict/skk/ari2nasi.rs
@@ -342,7 +342,9 @@ impl Ari2Nasi {
                 let yomi_base = &kana[0..kana.len() - last_char.len_utf8()].to_string();
                 for boin in self.boin_map.keys() {
                     let Some(okuri) = self
-                        .roman_map.get((last_char.to_string() + boin.to_string().as_str()).as_str()) else {
+                        .roman_map
+                        .get((last_char.to_string() + boin.to_string().as_str()).as_str())
+                    else {
                         // "wu" のような、平仮名に変換できない不正なローマ字パターンを生成しているケースもある。
                         // そういう場合は、スキップ。
                         continue;

--- a/libakaza/src/graph/graph_resolver.rs
+++ b/libakaza/src/graph/graph_resolver.rs
@@ -187,8 +187,7 @@ impl GraphResolver {
             return;
         }
 
-        let Some(targets) = lattice
-            .node_list(end_pos) else {
+        let Some(targets) = lattice.node_list(end_pos) else {
             // 直前のノードはない場合ある。
             return;
         };


### PR DESCRIPTION
## Summary
- Fix code formatting issues detected by `cargo fmt --check`

## Changes
Fix formatting for `let-else` statements in:
- `akaza-data/src/subcmd/learn_corpus.rs` (3 instances)
- `libakaza/src/dict/skk/ari2nasi.rs` (1 instance)
- `libakaza/src/graph/graph_resolver.rs` (1 instance)

## Background
The code was not following rustfmt's formatting standards for `let-else` syntax (introduced in Rust 1.65). This was causing CI failures on formatting checks.

## Testing
- `cargo fmt --all --check` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)