### PR TITLE
Fix clippy warnings (without dependency updates)

### DIFF
--- a/ibus-akaza/build.rs
+++ b/ibus-akaza/build.rs
@@ -1,19 +1,17 @@
-extern crate cc;
-
-use std::io::Read;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
 fn pkgconfig(module: &str, flag: &str) -> Vec<String> {
-    let child = Command::new("pkg-config")
+    let output = Command::new("pkg-config")
         .arg(module)
         .arg(flag)
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn child process");
-    let mut buf = String::new();
-    child.stdout.unwrap().read_to_string(&mut buf).unwrap();
-    let args: Vec<&str> = buf.trim().split(' ').collect();
-    args.iter().map(|f| f.to_string()).collect()
+        .output()
+        .expect("Failed to execute pkg-config");
+    let buf = String::from_utf8(output.stdout).expect("Invalid UTF-8 from pkg-config");
+    buf.trim()
+        .split(' ')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
 }
 
 fn main() {

--- a/libakaza/src/config.rs
+++ b/libakaza/src/config.rs
@@ -180,16 +180,11 @@ fn default_dict_usage() -> DictUsage {
     DictUsage::Disabled
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Default)]
 pub enum DictEncoding {
     EucJp,
+    #[default]
     Utf8,
-}
-
-impl Default for DictEncoding {
-    fn default() -> Self {
-        Utf8
-    }
 }
 
 impl Display for DictEncoding {
@@ -215,20 +210,15 @@ impl DictEncoding {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Default)]
 pub enum DictType {
+    #[default]
     SKK,
 }
 
 impl Display for DictType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
-    }
-}
-
-impl Default for DictType {
-    fn default() -> Self {
-        DictType::SKK
     }
 }
 
@@ -240,17 +230,12 @@ impl DictType {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Default)]
 pub enum DictUsage {
+    #[default]
     Normal,
     SingleTerm,
     Disabled,
-}
-
-impl Default for DictUsage {
-    fn default() -> Self {
-        Normal
-    }
 }
 
 impl DictUsage {

--- a/libakaza/src/extend_clause.rs
+++ b/libakaza/src/extend_clause.rs
@@ -16,7 +16,7 @@ fn keep_current(clauses: &[Vec<Candidate>]) -> Vec<Range<usize>> {
 
 /// 文節の選択範囲を右に拡張する。
 /// current_clause は現在選択されている分節。左から 0 origin である。
-pub fn extend_right(clauses: &Vec<Vec<Candidate>>, current_clause: usize) -> Vec<Range<usize>> {
+pub fn extend_right(clauses: &[Vec<Candidate>], current_clause: usize) -> Vec<Range<usize>> {
     // カラだったらなにもできない。
     if clauses.is_empty() {
         return Vec::new();
@@ -68,7 +68,7 @@ pub fn extend_right(clauses: &Vec<Vec<Candidate>>, current_clause: usize) -> Vec
 
 /// 文節の選択範囲を **左** に拡張する。
 /// current_clause は現在選択されている分節。左から 0 origin である。
-pub fn extend_left(clauses: &Vec<Vec<Candidate>>, current_clause: usize) -> Vec<Range<usize>> {
+pub fn extend_left(clauses: &[Vec<Candidate>], current_clause: usize) -> Vec<Range<usize>> {
     if clauses.is_empty() {
         return Vec::new();
     }

--- a/libakaza/src/graph/candidate.rs
+++ b/libakaza/src/graph/candidate.rs
@@ -17,7 +17,7 @@ impl Eq for Candidate {}
 
 impl PartialOrd<Self> for Candidate {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.cost.partial_cmp(&other.cost)
+        Some(self.cmp(other))
     }
 }
 

--- a/libakaza/src/graph/graph_resolver.rs
+++ b/libakaza/src/graph/graph_resolver.rs
@@ -57,10 +57,10 @@ impl GraphResolver {
                     // コストが最小な経路を選ぶようにする。
                     // そういうふうにコストを付与しているので。
                     if cost > tmp_cost {
-                        if shortest_prev.is_none() {
-                            trace!("Replace None by {}", prev);
+                        if let Some(prev_val) = shortest_prev {
+                            trace!("Replace {} by {}", prev_val, prev);
                         } else {
-                            trace!("Replace {} by {}", shortest_prev.unwrap(), prev);
+                            trace!("Replace None by {}", prev);
                         }
                         cost = tmp_cost;
                         shortest_prev = Some(prev);
@@ -75,9 +75,9 @@ impl GraphResolver {
         let eos = lattice
             .get((yomi.len() + 1) as i32)
             .unwrap()
-            .get(0)
+            .first()
             .unwrap();
-        let bos = lattice.get(0).unwrap().get(0).unwrap();
+        let bos = lattice.get(0).unwrap().first().unwrap();
         let mut node = eos;
         let mut result: Vec<Vec<Candidate>> = Vec::new();
         while node != bos {
@@ -262,7 +262,7 @@ impl Eq for BreakDown {}
 
 impl PartialOrd<Self> for BreakDown {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        (self.head_cost + self.tail_cost).partial_cmp(&(other.head_cost + other.tail_cost))
+        Some(self.cmp(other))
     }
 }
 

--- a/libakaza/src/graph/lattice_graph.rs
+++ b/libakaza/src/graph/lattice_graph.rs
@@ -45,7 +45,7 @@ impl<U: SystemUnigramLM, B: SystemBigramLM> LatticeGraph<U, B> {
     }
 
     pub(crate) fn get(&self, n: i32) -> Option<&Vec<WordNode>> {
-        return self.graph.get(&n);
+        self.graph.get(&n)
     }
 
     // for debugging purpose
@@ -127,7 +127,7 @@ impl<U: SystemUnigramLM, B: SystemBigramLM> LatticeGraph<U, B> {
             return user_cost;
         }
 
-        return if let Some((_, system_unigram_cost)) = node.word_id_and_score {
+        if let Some((_, system_unigram_cost)) = node.word_id_and_score {
             trace!("HIT!: {}, {}", node.key(), system_unigram_cost);
             system_unigram_cost
         } else if node.surface.len() < node.yomi.len() {
@@ -137,7 +137,7 @@ impl<U: SystemUnigramLM, B: SystemBigramLM> LatticeGraph<U, B> {
             self.system_unigram_lm.get_cost(1)
         } else {
             self.system_unigram_lm.get_cost(0)
-        };
+        }
     }
 
     pub(crate) fn get_edge_cost(&self, prev: &WordNode, node: &WordNode) -> f32 {

--- a/libakaza/src/graph/segmenter.rs
+++ b/libakaza/src/graph/segmenter.rs
@@ -79,8 +79,7 @@ impl Segmenter {
         // 終了位置ごとの候補単語リスト
         let mut words_ends_at: BTreeMap<usize, Vec<String>> = BTreeMap::new();
 
-        'queue_processing: while !queue.is_empty() {
-            let start_pos = queue.pop().unwrap();
+        'queue_processing: while let Some(start_pos) = queue.pop() {
             if seen.contains(&start_pos) {
                 continue;
             } else {

--- a/libakaza/src/lm/system_bigram.rs
+++ b/libakaza/src/lm/system_bigram.rs
@@ -110,9 +110,7 @@ impl MarisaSystemBigramLM {
             false
         });
 
-        let Some(key) = keys.get(0) else {
-            bail!("Cannot read default cost from bigram-trie");
-        };
+        let key = keys.first().context("Cannot read default cost from bigram-trie")?;
 
         let key = String::from_utf8_lossy(key);
         if let Some((_, score)) = key.split_once('\t') {
@@ -144,9 +142,7 @@ impl SystemBigramLM for MarisaSystemBigramLM {
             });
             true
         });
-        let Some(result) = got.first() else {
-            return None;
-        };
+        let result = got.first()?;
         let last2: [u8; 2] = result.keyword[result.keyword.len() - 2..result.keyword.len()]
             .try_into()
             .unwrap();

--- a/libakaza/src/user_side_data/bigram_user_stats.rs
+++ b/libakaza/src/user_side_data/bigram_user_stats.rs
@@ -34,9 +34,7 @@ impl BiGramUserStats {
      */
     pub(crate) fn get_cost(&self, key1: &str, key2: &str) -> Option<f32> {
         let key = key1.to_owned() + "\t" + key2;
-        let Some(count) = self.word_count.get(key.as_str()) else {
-            return None;
-        };
+        let count = self.word_count.get(key.as_str())?;
         Some(calc_cost(*count, self.unique_words, self.total_words))
     }
 

--- a/libakaza/src/user_side_data/unigram_user_stats.rs
+++ b/libakaza/src/user_side_data/unigram_user_stats.rs
@@ -32,9 +32,7 @@ impl UniGramUserStats {
      * ノードコストを計算する。
      */
     pub(crate) fn get_cost(&self, key: String) -> Option<f32> {
-        let Some(count) = self.word_count.get(key.as_str()) else {
-            return None;
-        };
+        let count = self.word_count.get(key.as_str())?;
 
         Some(calc_cost(*count, self.unique_words, self.total_words))
     }


### PR DESCRIPTION
## Summary
Fix clippy warnings without updating dependencies. This PR addresses warnings that can be fixed without requiring changes to Cargo.toml dependencies.

## Changes
- **build.rs**: Fix zombie process warning by using `Command::output()` instead of `spawn()`
- **Edition 2018+ style**: Remove unnecessary `extern crate` declarations
- **Derivable implementations**: Use `#[derive(Default)]` with `#[default]` attribute for enums
- **Function signatures**: Change `&Vec` parameters to `&[_]` slices
- **Trait implementations**: Fix non-canonical `PartialOrd` implementations
- **Code cleanup**: Remove needless return statements
- **Modern idioms**: 
  - Replace `while !vec.is_empty()` with `while let Some(...)`
  - Replace `.get(0)` with `.first()`
  - Replace `let...else` with `?` operator where applicable
- **Logic improvements**: Fix unnecessary `unwrap()` after `is_none()` check

## Testing
- All changes maintain the same behavior
- Clippy warnings resolved in libakaza and ibus-akaza/build.rs

## Note
Some packages (akaza-data, akaza-dict, akaza-conf) have compilation errors due to the `time` crate version incompatibility with the current Rust version. This will be addressed in a separate PR that updates dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)