### PR TITLE
Separate lint and test jobs in CI workflow

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -7,8 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +20,40 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install ibus libgirepository1.0-dev libmarisa-dev clang libibus-1.0-dev unzip libgtk-4-dev
+    - name: make some configuration files for ibus-akaza
+      run: |
+        cd ibus-akaza/ && make
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+          components: clippy, rustfmt
+    - name: Check formatting
+      run: cargo fmt --all --check
+    - name: Run clippy
+      run: cargo clippy -- -D warnings
+    - name: Install cargo-deny
+      run: cargo install --locked cargo-deny
+    - name: Run cargo-deny
+      run: cargo deny check
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -33,11 +65,5 @@ jobs:
       run: |
         cd ibus-akaza/ && make
     - uses: dtolnay/rust-toolchain@stable
-      with:
-          components: clippy, rustfmt
-    - run: cargo fmt --all --check
-    - run: cargo clippy -- -D warnings
-    - run: cargo test
-    - run: cargo install --locked cargo-deny
-    - run: cargo deny check
-
+    - name: Run tests
+      run: cargo test


### PR DESCRIPTION
## Summary
Split the CI workflow into two independent jobs that run in parallel instead of sequentially.

## Changes
### Before
Single `build` job that runs all checks sequentially:
1. fmt check
2. clippy check  
3. tests ← blocked if clippy fails
4. cargo-deny

### After
Two independent jobs running in parallel:
- **lint job**: fmt check, clippy check, cargo-deny
- **test job**: cargo test

## Benefits
- **Independence**: Lint failures no longer block test execution
- **Parallel execution**: Both jobs run simultaneously, improving CI speed
- **Better caching**: Each job has its own cache key (`cargo-lint-*` and `cargo-test-*`), improving cache hit rates
- **Clearer feedback**: Easier to identify whether a failure is lint-related or test-related

## Testing
The workflow will be validated when this PR is created and CI runs on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)