### PR TITLE
Add cargo-deny job to CI

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -37,6 +37,15 @@ jobs:
     - name: Run clippy
       run: cargo clippy -- -D warnings
 
+  cargo-deny:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Add cargo-deny as a separate CI job to check dependencies for:

- License compliance (OSI/FSF free licenses, no copyleft)
- Security advisories (unmaintained, unsound, yanked crates)

Runs in parallel with lint and test jobs to avoid slowing down the main checks.

Now works with Rust 1.77.0 (required by cargo-deny).

🤖 Generated with [Claude Code](https://claude.com/claude-code)