### PR TITLE
Upgrade Rust from 1.88.0 to 1.92.0

### DIFF
--- a/.github/workflows/ci-simple.yml
+++ b/.github/workflows/ci-simple.yml
@@ -30,7 +30,7 @@ jobs:
         cd ibus-akaza/ && make
     - uses: dtolnay/rust-toolchain@master
       with:
-          toolchain: "1.88.0"
+          toolchain: "1.92.0"
           components: clippy, rustfmt
     - name: Check formatting
       run: cargo fmt --all --check
@@ -72,6 +72,6 @@ jobs:
         cd ibus-akaza/ && make
     - uses: dtolnay/rust-toolchain@master
       with:
-          toolchain: "1.88.0"
+          toolchain: "1.92.0"
     - name: Run tests
       run: cargo test

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.92.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upgrade Rust version from 1.88.0 to 1.92.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)