### PR TITLE
Fix cargo-deny: Add Apache-2.0 WITH LLVM-exception to allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@ version = 2
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",


### PR DESCRIPTION
Fix cargo-deny failure by adding `Apache-2.0 WITH LLVM-exception` to the allowed licenses list.

This license is used by `target-lexicon` and is a standard OSI-approved license.

Fixes the error:
```
error[rejected]: failed to satisfy license requirements
   ┌─ /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/target-lexicon-0.12.16/Cargo.toml:33:12
   │
33 │ license = "Apache-2.0 WITH LLVM-exception"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)