### PR TITLE
Add Unicode-3.0 to allowed licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ allow = [
     "BSL-1.0",
     "MPL-2.0",
     "Unlicense",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
 ]
 


### PR DESCRIPTION
## Summary
- Add Unicode-3.0 to the allowed licenses list in deny.toml

## Details
Fixes the cargo-deny license check failure for the `unicode-ident` crate, which uses `(MIT OR Apache-2.0) AND Unicode-3.0` license.

This is the second license rejection from the CI run that needed to be addressed after the Apache-2.0 WITH LLVM-exception fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)