### PR TITLE
Update vibrato from 0.3.3 to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,9 +1838,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vibrato"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87764b9827d5b17cfadc078782567d73cffcb4568e8bfddaa4cd1903c066af65"
+checksum = "fbded95c0134b5c84bf18464d9696dae2bf73d7aca6ad5b2fb9bb12a84a13cf8"
 dependencies = [
  "bincode 2.0.0-rc.2",
  "bincode_derive",

--- a/akaza-data/Cargo.toml
+++ b/akaza-data/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1"
 kelp = "0.4.0"
 lcs = "0.2.0"
 chrono = "0.4.23"
-vibrato = "0.3.3"
+vibrato = "0.4.0"
 walkdir = "2"
 rayon = "1.6.1"
 marisa-sys = { path = "../marisa-sys" }


### PR DESCRIPTION
## Summary
- Update vibrato from 0.3.3 to 0.4.0

## Changes
- Main feature: Support for zstd-compressed dictionaries in all CLIs ([#112](https://github.com/daac-tools/vibrato/pull/112))
- No breaking changes to the API

## Unmaintained Dependencies Note
This version still uses `rucrf 0.3.2` which transitively depends on unmaintained crates:
- bincode 1.3.3 and 2.0.0-rc.2 (via argmin 0.7.0)
- instant 0.1.13 (via argmin 0.7.0)  
- paste 1.0.15 (via argmin 0.7.0)

These unmaintained crates are only used in the training features via the dependency chain:
`vibrato` → `rucrf` → `argmin` → `{bincode, instant, paste}`

## Future Work
Vibrato 0.5.2 is available which updates to:
- rucrf 0.3.3 (uses argmin 0.10.0 with reduced dependencies)
- bincode 2.0.1 (stable version, no longer RC)
- Requires Rust 1.85

However, this can be done in a separate PR after we upgrade our Rust version.

## References
- [vibrato 0.4.0 release](https://github.com/daac-tools/vibrato/releases/tag/v0.4.0)
- [vibrato repository](https://github.com/daac-tools/vibrato)

🤖 Generated with [Claude Code](https://claude.com/claude-code)