### PR TITLE
Fix tagpr workflow to use GitHub App token

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -13,8 +13,16 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ vars.TAGPR_APP_ID }}
+          private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
 
-      - uses: Songmu/tagpr@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: Songmu/tagpr@0a9ef64ad975dce30c6fb2547f9e1ac89b5f1f76 # v1.11.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
Fix tagpr workflow to use GitHub App token instead of the default GITHUB_TOKEN. This is necessary because workflows triggered by GITHUB_TOKEN don't trigger other workflows, which means CI won't run on tagpr's release PRs.

## Changes
- Use `actions/create-github-app-token` to generate a GitHub App token
- Pin all action versions to commit hashes for security
- Update to latest stable versions:
  - `actions/checkout@v4.3.1`
  - `actions/create-github-app-token@v1.12.0`
  - `Songmu/tagpr@v1.11.0`

## GitHub App Setup Required

After merging this PR, you need to set up a GitHub App:

### 1. Create GitHub App

Go to https://github.com/settings/apps/new and create a new GitHub App with:

**Repository permissions:**
- Contents: Read and write
- Pull requests: Read and write

**Where can this GitHub App be installed?**
- Only on this account

### 2. Install the App

After creating the app:
1. Go to the app's settings page
2. Click "Install App" in the left sidebar
3. Install it to the `akaza-im` organization (or your account)
4. Select "Only select repositories" and choose `akaza`

### 3. Set Repository Variables/Secrets

In the repository settings (https://github.com/akaza-im/akaza/settings/secrets/actions):

**Variables** (Repository variables):
- `TAGPR_APP_ID`: The App ID from the app's settings page

**Secrets** (Repository secrets):
- `TAGPR_APP_PRIVATE_KEY`: Generate a private key from the app's settings page and paste the entire content

### 4. Test

After setup, the next push to `main` should trigger tagpr with the GitHub App token, and CI should run on the created release PR.

## References
- Reference implementation: https://github.com/tokuhirom/apprun-dedicated-provisioner/blob/main/.github/workflows/tagpr.yml
- Why GitHub App token is needed: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)