### PR TITLE
make install-model ターゲットを追加し、make install に統合

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ DATADIR ?= $(PREFIX)/share
 all:
 	$(MAKE) -C ibus-akaza all
 
-install: install-resources
+install: install-resources install-model
 	$(MAKE) -C ibus-akaza install
+
+install-model:
+	mkdir -p $(DATADIR)/akaza/model/default/
+	curl -L https://github.com/akaza-im/akaza-default-model/releases/latest/download/akaza-default-model.tar.gz | \
+		tar xzv --strip-components=1 -C $(DATADIR)/akaza/model/default/
 
 install-resources:
 	install -m 0644 -v -D -t $(DATADIR)/akaza/romkan romkan/*
@@ -34,6 +39,6 @@ docker-test-e2e:
 docker-test-shell:
 	docker compose -f docker-compose.test.yml run --rm test bash
 
-.PHONY: all install install-resources clean \
+.PHONY: all install install-model install-resources clean \
 	docker-test-build docker-test docker-test-unit docker-test-integration docker-test-e2e docker-test-shell
 

--- a/README.md
+++ b/README.md
@@ -76,17 +76,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup install stable
 ```
 
-### 3. モデルファイルのダウンロード
-
-最新のモデルファイルを [akaza-default-model releases](https://github.com/akaza-im/akaza-default-model/releases) からダウンロードしてください。
-
-```bash
-sudo mkdir -p /usr/share/akaza/model/default/
-curl -L https://github.com/akaza-im/akaza-default-model/releases/latest/download/akaza-default-model.tar.gz | \
-    sudo tar xzv --strip-components=1 -C /usr/share/akaza/model/default/
-```
-
-### 4. ibus-akaza のビルドとインストール
+### 3. ibus-akaza のビルドとインストール
 
 ```bash
 git clone https://github.com/akaza-im/akaza.git
@@ -95,7 +85,9 @@ make
 sudo make install
 ```
 
-### 5. IBus の再起動と有効化
+`make install` により、モデルファイル（[akaza-default-model](https://github.com/akaza-im/akaza-default-model)）のダウンロードとインストールも自動で行われます。
+
+### 4. IBus の再起動と有効化
 
 ```bash
 ibus restart


### PR DESCRIPTION
## Summary

- Makefile に `install-model` ターゲットを追加し、akaza-default-model のダウンロードとインストールを自動化
- `make install` 実行時に `install-model` も自動で実行されるように変更
- README.md のインストール手順を簡略化（手動モデルダウンロードのステップを削除し、5ステップから4ステップに）

## 変更内容

### Makefile
- `install-model` ターゲットを新規追加。akaza-default-model の最新リリースを `$(DATADIR)/akaza/model/default/` にダウンロード・展開する
- `install` ターゲットの依存に `install-model` を追加
- `.PHONY` に `install-model` を追加

### README.md
- モデルファイルの手動ダウンロード手順（旧ステップ3）を削除
- `make install` でモデルも自動インストールされる旨を補足
- ステップ番号を整理（5→4ステップに）

🤖 Generated with [Claude Code](https://claude.com/claude-code)