### PR TITLE
プリエディット属性の範囲指定ミスによる gnome-terminal クラッシュを修正

### DIFF
--- a/ibus-akaza/src/current_state.rs
+++ b/ibus-akaza/src/current_state.rs
@@ -408,14 +408,19 @@ impl CurrentState {
                 .iter()
                 .map(|c| c[0].surface.chars().count() as u32)
                 .sum();
-            // 背景色を設定する。
+            // 背景色を設定する（bgstart から preedit 末尾まで）。
+            // end_index は preedit 全体の文字数を超えてはならない。
+            // 以前は bgstart + preedit_char_len としていたため、プリエディット文字列の
+            // 長さを超える属性範囲が VTE (libvte) に渡り、fudge_pango_colors() 内で
+            // 整数アンダーフローによるスタックオーバーフローを引き起こし、
+            // gnome-terminal が SIGSEGV でクラッシュしていた。
             ibus_attr_list_append(
                 preedit_attrs,
                 ibus_attribute_new(
                     IBusAttrType_IBUS_ATTR_TYPE_BACKGROUND,
                     0x00333333,
                     bgstart,
-                    bgstart + (preedit_char_len as u32),
+                    preedit_char_len,
                 ),
             );
             let preedit_text = self.preedit.to_ibus_text();


### PR DESCRIPTION
## Summary

- プリエディット背景色属性の `end_index` が不正な値になっており、gnome-terminal が SIGSEGV でクラッシュする問題を修正

## 問題の詳細

### 症状

gnome-terminal 上で ibus-akaza を使って日本語入力中に、gnome-terminal が SIGSEGV でクラッシュする。dmesg には以下のようなログが記録される：

```
gnome-terminal-[4417]: segfault at 7ffe9208d3a8 ip 000073a52dd54d15 sp 00007ffe9208c3b0 error 6 in libvte-2.91.so.0.7600.0[35d15,...]
```

4回のクラッシュすべてが libvte の同一オフセット `0x35d15` で発生。

### 原因

`render_preedit()` で背景色属性を設定する際、`end_index` を `bgstart + preedit_char_len` としていた。

- `bgstart`: 変換済み部分の文字数（例: 6）
- `preedit_char_len`: プリエディット全体の文字数（例: 10）
- 結果の `end_index`: 16（プリエディットの実際の長さ 10 を超える）

この範囲外の属性が VTE (libvte 0.76.0) に渡ると、`translate_pango_cells()` → `fudge_pango_colors()` で以下の計算が行われる：

```c
// vte.cc:9149-9150
n = MIN(n_cells, attr->end_index) - attr->start_index;
```

`attr->start_index` が `n_cells` を超えている場合、`gsize`（符号なし）の減算でアンダーフローが発生し `n = 0xFFFFFFFFFFFFFFFE` となる。その後 `g_newa(struct, n)` でスタック上に巨大なメモリを確保しようとし、スタックオーバーフロー → SIGSEGV。

### クラッシュ時のバックトレース（debuginfod によるシンボル解決済み）

```
#0  vte::terminal::Terminal::fudge_pango_colors (n=18446744073709551614) at ../src/vte.cc:8954
#1  vte::terminal::Terminal::translate_pango_cells () at ../src/vte.cc:9145
#2  vte::terminal::Terminal::draw_cells_with_attributes () at ../src/vte.cc:9184
#3  vte::terminal::Terminal::paint_im_preedit_string () at ../src/vte.cc:9807
#4  vte::terminal::Terminal::draw () at ../src/vte.cc:9958
#5  vte::terminal::Terminal::widget_draw () at ../src/vte.cc:9862
#6  vte_terminal_draw () at ../src/vtegtk.cc:710
```

### 修正内容

`end_index` を `bgstart + preedit_char_len` から `preedit_char_len` に修正。背景色属性の範囲を「`bgstart` から `preedit_char_len`（プリエディット末尾）まで」に正しく設定した。

## 環境

- Pop!_OS 24.04
- libvte 0.76.0-1ubuntu0.1
- gnome-terminal 3.52.0-1ubuntu2
- Linux 6.16.3-76061603-generic

## テスト結果

- `cargo test --lib --package ibus-akaza`: 29 passed
- `cargo clippy --all-targets --all-features`: 既存の warning のみ（今回の変更に関するものなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)