### PR TITLE
akaza-dict の引数不足クラッシュを回避

### DIFF
--- a/akaza-dict/src/bin/akaza-dict.rs
+++ b/akaza-dict/src/bin/akaza-dict.rs
@@ -12,6 +12,9 @@ fn main() -> Result<()> {
         .try_init();
 
     let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        anyhow::bail!("Usage: akaza-dict <user_dict_path>");
+    }
     open_userdict_window(&args[1])?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- 引数未指定で実行したときに usage を表示して終了するように変更

## 変更内容の詳細
- akaza-dict の引数チェックを追加し、index out of bounds を回避

## テスト
- 未実行（引数チェックのみ）

Related: #355
