### PR TITLE
設定保存時にconfigディレクトリを作成

### DIFF
--- a/libakaza/src/config.rs
+++ b/libakaza/src/config.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::{BufReader, Write};
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
@@ -96,11 +96,14 @@ impl Config {
         let file_name = Self::file_name()?;
         let yml = serde_yaml::to_string(self)?;
         if let Some(parent) = file_name.parent() {
-            std::fs::create_dir_all(parent)?;
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Cannot create config dir: {}", parent.display()))?;
         }
         info!("Write to file: {}", file_name.display());
-        let mut fp = File::create(file_name)?;
-        fp.write_all(yml.as_bytes())?;
+        let mut fp = File::create(&file_name)
+            .with_context(|| format!("Cannot open config file: {}", file_name.display()))?;
+        fp.write_all(yml.as_bytes())
+            .with_context(|| format!("Cannot write config file: {}", file_name.display()))?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- 設定保存前に ~/.config/akaza ディレクトリを作成

## 変更内容の詳細
- Config::save で parent ディレクトリを create_dir_all

## テスト
- 未実行（保存処理のみ）

Related: なし
