### PR TITLE
akaza-conf のOK後にウィンドウを閉じる

### DIFF
--- a/akaza-conf/src/conf.rs
+++ b/akaza-conf/src/conf.rs
@@ -55,6 +55,7 @@ fn connect_activate(app: &Application, config: Arc<Mutex<Config>>) -> Result<()>
     grid.attach(&notebook, 0, 0, 6, 1);
 
     let ok_button = Button::with_label("OK");
+    let window_for_ok = window.clone();
     ok_button.connect_clicked(move |_| {
         eprintln!("Save the configuration...");
         // TODO: 保存処理
@@ -106,6 +107,7 @@ fn connect_activate(app: &Application, config: Arc<Mutex<Config>>) -> Result<()>
                 dialog.show();
             }
         }
+        window_for_ok.close();
     });
     let cancel_button = Button::with_label("Cancel");
     {


### PR DESCRIPTION
## Summary
- OK ボタン処理の最後で設定ウィンドウを閉じる

## 変更内容の詳細
- OK 後に window.close() を追加

## テスト
- 未実行（UI挙動のみ）

Related: なし
