### PR TITLE
入力モードメニューのチェック状態を同期

### DIFF
--- a/ibus-akaza/src/ui/prop_controller.rs
+++ b/ibus-akaza/src/ui/prop_controller.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Result;
-use log::error;
 
 use ibus_sys::core::to_gboolean;
 use ibus_sys::engine::{ibus_engine_register_properties, ibus_engine_update_property, IBusEngine};


### PR DESCRIPTION
## Summary
- 入力モード切替時に選択中以外のメニュー項目を確実に unchecked にする

## 変更内容の詳細
- PropController::set_input_mode で全項目を更新

## テスト
- 未実行（UI挙動のみ）

Related: なし
