### PR TITLE
ユーザー辞書は外部プロセスで起動

### DIFF
--- a/ibus-akaza/src/context.rs
+++ b/ibus-akaza/src/context.rs
@@ -97,8 +97,16 @@ impl AkazaContext {
                 .arg(dict_path)
                 .spawn()
             {
-                Ok(_) => {}
-                Err(e) => error!("Failed to launch akaza-dict: {}", e),
+                Ok(_) => {
+                    self.current_state.set_auxiliary_text(engine, "");
+                }
+                Err(e) => {
+                    error!("Failed to launch akaza-dict: {}", e);
+                    self.current_state.set_auxiliary_text(
+                        engine,
+                        &format!("ユーザー辞書を起動できません: {}", e),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- ibus-akaza から akaza-dict を直接起動せず、外部プロセスとして起動する

## 変更内容の詳細
- do_property_activate で  を  で起動
- in-process の GUI 起動をやめて OOM/リークのリスクを回避

## テスト
- 未実行（UI挙動のみ）

Related: なし
