### PR TITLE
デバッグ用スクリプト名を整理

### DIFF
--- a/ibus-akaza/Makefile
+++ b/ibus-akaza/Makefile
@@ -27,7 +27,7 @@ akaza.xml: akaza.xml.in
 
 akaza-debug.xml: akaza.xml.in
 	sed \
-	    -e "s:@BINARY@:$(MKFILE_DIR)/ibus-akaza-debug.sh:g" \
+	    -e "s:@BINARY@:$(MKFILE_DIR)/ibus-akaza-debug-engine.sh:g" \
 	    -e "s:@DATADIR@:$(DATADIR)/:g" $< > $@
 
 install: akaza.xml config.h ../target/release/ibus-akaza
@@ -54,4 +54,3 @@ clean:
 	rm -f akaza.xml config.h
 
 .PHONY: all test install uninstall clean install-debug
-

--- a/ibus-akaza/README.md
+++ b/ibus-akaza/README.md
@@ -12,5 +12,4 @@ akaza の ibus binding です。
 
 `sudo make install-debug` とすると、`../target/debug/ibus-akaza` を利用して起動するように `/usr/share/ibus/component/akaza.xml` が設定されます。
 
-この状態で `./debug.sh` すると、ibus が再起動されて、ログファイルが表示されるようになります。
-
+この状態で `./ibus-akaza-debug-session.sh` を実行すると、ibus が再起動されて、ログファイルが表示されるようになります。

--- a/ibus-akaza/ibus-akaza-debug-engine.sh
+++ b/ibus-akaza/ibus-akaza-debug-engine.sh
@@ -5,7 +5,8 @@ BASEDIR=$(dirname "$0")
 
 umask 077
 
-exec 1>> ~/.ibus-akaza.log
+LOG_PATH="${HOME}/.cache/akaza/logs/ibus-akaza.log"
+exec 1>> "$LOG_PATH"
 exec 2>&1
 
 export RUST_BACKTRACE=4

--- a/ibus-akaza/ibus-akaza-debug-session.sh
+++ b/ibus-akaza/ibus-akaza-debug-session.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -x
+LOG_PATH="${HOME}/.cache/akaza/logs/ibus-akaza.log"
+
 cargo build --release || { echo 'cannot build.' ; exit 1; }
 ibus restart
 ibus engine akaza
-tail -F ~/.ibus-akaza.log
+tail -F "$LOG_PATH"


### PR DESCRIPTION
Summary:\n- デバッグ用スクリプトの名前を整理\n- ログ出力先のパスに合わせてスクリプトとREADMEを更新\n\n変更内容:\n- debug.sh -> ibus-akaza-debug-session.sh\n- ibus-akaza-debug.sh -> ibus-akaza-debug-engine.sh\n- ibus-akaza/Makefile と README の参照更新\n\nテスト:\n- 未実行\n\nRelated: なし\n