### PR TITLE
設定メニューが動作しない問題を修正

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,8 +935,6 @@ dependencies = [
 name = "ibus-akaza"
 version = "0.1.7"
 dependencies = [
- "akaza-conf",
- "akaza-dict",
  "anyhow",
  "cc",
  "chrono",

--- a/ibus-akaza/Cargo.toml
+++ b/ibus-akaza/Cargo.toml
@@ -20,8 +20,6 @@ anyhow = "1.0"
 log = "0.4"
 libakaza = { path = "../libakaza" }
 ibus-sys = { path = "../ibus-sys" }
-akaza-conf = { path = "../akaza-conf" }
-akaza-dict = { path = "../akaza-dict" }
 env_logger = "0.11"
 clap = { version = "4.5", features = ["derive"] }
 clap-verbosity-flag = "2.2"

--- a/ibus-akaza/src/main.rs
+++ b/ibus-akaza/src/main.rs
@@ -53,14 +53,15 @@ unsafe extern "C" fn property_activate(
     prop_name: *mut gchar,
     prop_state: guint,
 ) {
-    let context_ref = &mut *(context as *mut AkazaContext);
-    context_ref.do_property_activate(
-        engine,
-        CStr::from_ptr(prop_name as *mut c_char)
-            .to_string_lossy()
-            .to_string(),
-        prop_state,
+    let prop_name_str = CStr::from_ptr(prop_name as *mut c_char)
+        .to_string_lossy()
+        .to_string();
+    info!(
+        "property_activate callback fired: prop_name={:?}, prop_state={}",
+        prop_name_str, prop_state
     );
+    let context_ref = &mut *(context as *mut AkazaContext);
+    context_ref.do_property_activate(engine, prop_name_str, prop_state);
 }
 
 fn load_user_data() -> Arc<Mutex<UserData>> {

--- a/ibus-akaza/src/ui/prop_controller.rs
+++ b/ibus-akaza/src/ui/prop_controller.rs
@@ -181,7 +181,7 @@ impl PropController {
     unsafe fn build_preference_menu(prop_list: *mut IBusPropList) {
         let preference_prop = g_object_ref_sink(ibus_property_new(
             c"PrefPane".as_ptr() as *const gchar,
-            IBusPropType_PROP_TYPE_MENU,
+            IBusPropType_PROP_TYPE_NORMAL,
             "設定".to_ibus_text(),
             c"".as_ptr() as *const gchar,
             "Preference".to_ibus_text(),


### PR DESCRIPTION
## Summary

- 設定メニュー（PrefPane）をクリックしても何も起きない問題を修正
- 設定画面（akaza-conf）を別プロセスで起動するように変更

## 変更内容

- **PrefPane の IBusPropType を `MENU` → `NORMAL` に変更**: `PROP_TYPE_MENU` はサブメニュー展開のみで `property_activate` コールバックが発火しないため、クリックしても何も起きなかった
- **`open_configuration_window()` → `Command::new("akaza-conf").spawn()`**: 設定画面を別プロセスで起動。ユーザー辞書（#372）と同様にプロセス分離を実現
- **ibus-akaza から `akaza-conf`, `akaza-dict` crate の依存を除去**: コマンドとして外部起動するのみのため不要。ibus-akaza のビルドから GTK4 関連の依存が減る
- **ログ追加**: `property_activate` コールバック発火時、`akaza-conf` の PATH 確認・起動時のログを追加

Related: #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)