### PR TITLE
preedit テキストが黒背景に黒文字で見えない問題を修正

### DIFF
--- a/ibus-akaza/src/current_state.rs
+++ b/ibus-akaza/src/current_state.rs
@@ -7,7 +7,8 @@ use log::{error, info};
 use ibus_sys::attr_list::{ibus_attr_list_append, ibus_attr_list_new};
 use ibus_sys::attribute::{
     ibus_attribute_new, IBusAttrType_IBUS_ATTR_TYPE_BACKGROUND,
-    IBusAttrType_IBUS_ATTR_TYPE_UNDERLINE, IBusAttrUnderline_IBUS_ATTR_UNDERLINE_SINGLE,
+    IBusAttrType_IBUS_ATTR_TYPE_FOREGROUND, IBusAttrType_IBUS_ATTR_TYPE_UNDERLINE,
+    IBusAttrUnderline_IBUS_ATTR_UNDERLINE_SINGLE,
 };
 use ibus_sys::core::to_gboolean;
 use ibus_sys::engine::{
@@ -426,6 +427,16 @@ impl CurrentState {
                 ibus_attribute_new(
                     IBusAttrType_IBUS_ATTR_TYPE_BACKGROUND,
                     0x00333333,
+                    bgstart,
+                    preedit_char_len,
+                ),
+            );
+            // 背景色が濃いため、前景色を白にして視認性を確保する。
+            ibus_attr_list_append(
+                preedit_attrs,
+                ibus_attribute_new(
+                    IBusAttrType_IBUS_ATTR_TYPE_FOREGROUND,
+                    0x00FFFFFF,
                     bgstart,
                     preedit_char_len,
                 ),


### PR DESCRIPTION
## Summary

- preedit の未確定部分が黒背景に黒文字で見えなくなる問題を修正
- 背景色に合わせて前景色（白）を明示的に設定

## 変更内容

`render_preedit()` で背景色 `0x333333`（濃いグレー）を設定している範囲に、前景色が未設定だったため、アプリケーションのテーマやテキストのデフォルト色によっては黒文字のまま濃いグレー背景になり、preedit テキストが見えなくなっていた。

`IBusAttrType_IBUS_ATTR_TYPE_FOREGROUND` で `0xFFFFFF`（白）を同じ範囲に設定することで、背景色に対して常に視認できるようにした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)