### PR TITLE
wordcnt-unigram: homograph_hack / score_hack を除去

### DIFF
--- a/akaza-data/src/subcmd/make_stats_system_unigram_lm.rs
+++ b/akaza-data/src/subcmd/make_stats_system_unigram_lm.rs
@@ -1,4 +1,3 @@
-use std::cmp::max;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
@@ -12,7 +11,7 @@ pub fn make_stats_system_unigram_lm(srcpath: &str, dstpath: &str) -> anyhow::Res
     // 16 はヒューリスティックな値。調整の余地。
     let threshold = 16_u32;
 
-    let mut wordcnt = parse_wfreq(srcpath, threshold)?;
+    let wordcnt = parse_wfreq(srcpath, threshold)?;
     if wordcnt.len() >= 8388608 {
         // edge cost 言語モデルファイルの容量を小さく保つために
         // 3 byte に ID が収めるようにする。
@@ -20,9 +19,6 @@ pub fn make_stats_system_unigram_lm(srcpath: &str, dstpath: &str) -> anyhow::Res
         // 現実的な線で切っても、500万単語ぐらいで十分。
         panic!("too much words in wfreq file: {srcpath}");
     }
-
-    homograph_hack(&mut wordcnt);
-    score_hack(&mut wordcnt);
 
     let mut builder = WordcntUnigramBuilder::default();
     for (word, score) in &wordcnt {
@@ -33,43 +29,6 @@ pub fn make_stats_system_unigram_lm(srcpath: &str, dstpath: &str) -> anyhow::Res
     builder.save(dstpath)?;
 
     Ok(())
-}
-
-fn homograph_hack(wordcnt: &mut HashMap<String, u32>) {
-    // 同形異音字の処理
-    // mecab では "日本" は "日本/にほん" に処理されるため、日本/にっぽん が表出しない。
-    // かな漢字変換上は、同一程度の確率で出るだろうと予想されることから、この2つの確率を同じに設定する。
-    {
-        let (src, dst) = ("日本/にほん", "日本/にっぽん");
-        try_copy_cost(src, dst, wordcnt);
-        try_copy_cost(dst, src, wordcnt);
-    }
-}
-
-fn try_copy_cost(word1: &str, word2: &str, wordcnt: &mut HashMap<String, u32>) {
-    if !wordcnt.contains_key(word2) {
-        if let Some(cost) = wordcnt.get(word1) {
-            wordcnt.insert(word2.to_string(), *cost);
-        }
-    }
-}
-
-// Wikipedia 特有で、日本語の一般的な分布よりも少しずれたスコアをつけている時があるので
-// ヒューリスティックに調整する。
-fn score_hack(wordcnt: &mut HashMap<String, u32>) {
-    // a の方のスコアが b よりも高くなるように調整します。
-    // https://github.com/tokuhirom/akaza/wiki/%E5%A4%A7%E5%AD%97
-    // https://github.com/tokuhirom/akaza/wiki/%E5%8D%BF
-    for (a, b) in [("今日/きょう", "卿/きょう"), ("大事/だいじ", "大字/だいじ")]
-    {
-        let Some(a_score) = wordcnt.get(a) else {
-            return;
-        };
-        let Some(b_score) = wordcnt.get(b) else {
-            return;
-        };
-        wordcnt.insert(a.to_string(), max(*a_score, b_score + 1));
-    }
 }
 
 fn parse_wfreq(src_file: &str, threshold: u32) -> anyhow::Result<HashMap<String, u32>> {


### PR DESCRIPTION
## Summary

- `make_stats_system_unigram_lm.rs` からハードコードされたスコア調整を除去
  - `homograph_hack`: 日本/にほん と 日本/にっぽん の頻度同期
  - `score_hack`: 今日/きょう vs 卿/きょう、大事/だいじ vs 大字/だいじ の調整

## 背景

これらのハックは Wikipedia コーパスの統計バイアスを補正するものだったが、akaza-default-model のコーパス (`learn-corpus`) で代替可能。

対応する akaza-default-model 側の PR: https://github.com/akaza-im/akaza-default-model/pull/new/add-corpus-for-score-hacks

Closes #382

## 検証結果

ハック除去後にモデルを再ビルドし、`make evaluate` で精度が維持されることを確認済み (再現率 91.15%)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)