### PR TITLE
evaluate: [BAD] ログ行に入力の読みを追加

### DIFF
--- a/akaza-data/src/subcmd/evaluate.rs
+++ b/akaza-data/src/subcmd/evaluate.rs
@@ -116,6 +116,7 @@ pub fn evaluate(
                 info!("{} => (teacher={}, akaza={})", yomi, surface, got);
                 good_cnt += 1;
             } else {
+                println!("[BAD] '{}' '{}' '{}'", yomi, surface, got);
                 println!(
                     "{} =>\n\
                    |  corpus={}\n\


### PR DESCRIPTION
## Summary

- `evaluate` コマンドの `[BAD]` ログ行に入力の読み（yomi）を追加
- ログ解析時に、どの入力に対して変換が失敗したか一行で把握できるようにした

## 変更内容

出力形式: `[BAD] 'よみ' '期待される表層形' '実際の変換結果'`

## Test plan

- [ ] `akaza-data evaluate` を実行し、[BAD] 行に読み・期待値・実際の結果が出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)