### PR TITLE
tokenize-line: stdin からの複数行入力に対応

### DIFF
--- a/akaza-data/src/main.rs
+++ b/akaza-data/src/main.rs
@@ -93,7 +93,7 @@ struct TokenizeLineArgs {
     system_dict: String,
     #[arg(long)]
     kana_preferred: bool,
-    text: String,
+    text: Option<String>,
 }
 
 /// トーカナイズされたコーパスから単語頻度ファイルを生成する
@@ -252,7 +252,7 @@ fn main() -> anyhow::Result<()> {
             opt.system_dict.as_str(),
             opt.user_dict,
             opt.kana_preferred,
-            opt.text.as_str(),
+            opt.text,
         ),
         Commands::Wfreq(opt) => wfreq(&opt.src_dir, opt.dst_file.as_str()),
         Commands::Vocab(opt) => vocab(opt.src_file.as_str(), opt.dst_file.as_str(), opt.threshold),

--- a/akaza-data/src/subcmd/tokenize_line.rs
+++ b/akaza-data/src/subcmd/tokenize_line.rs
@@ -1,18 +1,36 @@
+use std::io::{self, BufRead};
+
 use log::info;
 
 use crate::tokenizer::base::AkazaTokenizer;
 use crate::tokenizer::vibrato::VibratoTokenizer;
 
 /// 一行の自然文を `surface/yomi` 形式で出力する。
+/// `text` が `Some` の場合は引数の1行を処理し、`None` の場合は stdin から行ごとに処理する。
 pub fn tokenize_line(
     system_dict: &str,
     user_dict: Option<String>,
     kana_preferred: bool,
-    text: &str,
+    text: Option<String>,
 ) -> anyhow::Result<()> {
-    info!("tokenize-line: {}", text);
     let tokenizer = VibratoTokenizer::new(system_dict, user_dict)?;
-    let annotated = tokenizer.tokenize(text, kana_preferred)?;
-    println!("{annotated}");
+
+    match text {
+        Some(text) => {
+            info!("tokenize-line: {}", text);
+            let annotated = tokenizer.tokenize(&text, kana_preferred)?;
+            println!("{annotated}");
+        }
+        None => {
+            let stdin = io::stdin();
+            for line in stdin.lock().lines() {
+                let line = line?;
+                info!("tokenize-line: {}", line);
+                let annotated = tokenizer.tokenize(&line, kana_preferred)?;
+                println!("{annotated}");
+            }
+        }
+    }
+
     Ok(())
 }

--- a/akaza-data/src/tokenizer/vibrato.rs
+++ b/akaza-data/src/tokenizer/vibrato.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 
 use anyhow::Context;
 use kelp::{kata2hira, ConvOption};
-use log::info;
+use log::{debug, info};
 use vibrato::{Dictionary, Tokenizer};
 
 use crate::tokenizer::base::{merge_terms_ipadic, AkazaTokenizer, IntermediateToken};
@@ -18,7 +18,7 @@ impl VibratoTokenizer {
         let t1 = SystemTime::now();
         let mut dict = Dictionary::read(File::open(dictpath)?)?;
         let t2 = SystemTime::now();
-        println!(
+        debug!(
             "Loaded {} in {}msec",
             dictpath,
             t2.duration_since(t1)?.as_millis()


### PR DESCRIPTION
## Summary

- `tokenize-line` サブコマンドの `text` 引数を省略可能にし、省略時は stdin から行ごとに読み取るようにした
- 辞書ロードを1回だけ行い各行に対して tokenize を呼ぶため、複数行処理時のパフォーマンスが大幅に改善される
- vibrato の辞書ロードログを `println!` から `debug!` に変更し、stdout の汚染を防止

## 変更内容

### `akaza-data/src/main.rs`
- `TokenizeLineArgs.text` を `String` → `Option<String>` に変更

### `akaza-data/src/subcmd/tokenize_line.rs`
- `text` が `Some` の場合: 従来通り1行処理
- `text` が `None` の場合: `stdin.lock().lines()` で行ごとに処理
- 辞書ロード(`VibratoTokenizer::new`)は1回だけ実行

### `akaza-data/src/tokenizer/vibrato.rs`
- 辞書ロード時のログ出力を `println!` → `debug!` に変更

## 使い方

```bash
# 従来通り（引数指定）
akaza-data tokenize-line --system-dict dict.dic "わたしはにほんごがすきです。"

# stdin から複数行
echo -e "わたしはにほんごがすきです。\nきょうはいいてんきですね。" | \
  akaza-data tokenize-line --system-dict dict.dic
```

## Test plan

- [x] `cargo test --package akaza-data` 全11テスト pass
- [x] `cargo build --package akaza-data` ビルド成功
- [ ] 引数指定での動作確認
- [ ] stdin からの複数行入力での動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)