### PR TITLE
evaluate: [BAD] ログを2行形式に簡潔化

### DIFF
--- a/akaza-data/src/subcmd/evaluate.rs
+++ b/akaza-data/src/subcmd/evaluate.rs
@@ -116,15 +116,9 @@ pub fn evaluate(
                 info!("{} => (teacher={}, akaza={})", yomi, surface, got);
                 good_cnt += 1;
             } else {
-                println!("[BAD] '{}' '{}' '{}'", yomi, surface, got);
+                println!("[BAD] {} => corpus={}, akaza={}", yomi, surface, got);
                 println!(
-                    "{} =>\n\
-                   |  corpus={}\n\
-                   |  akaza ={}\n\
-                   Good count={} bad count={} elapsed={}ms saigen={}",
-                    yomi,
-                    surface,
-                    got,
+                    "Good count={} bad count={} elapsed={}ms saigen={}",
                     good_cnt,
                     bad_cnt,
                     elapsed.as_millis(),


### PR DESCRIPTION
## Summary

- evaluate の [BAD] 時のログ出力を3行形式から2行形式に簡潔化
- 冗長な `corpus=` / `akaza=` の複数行出力を廃止し、`[BAD]` 行と `Good count` 行のみに変更

## 変更前
```
[BAD] 'yomi' 'surface' 'got'
yomi =>
   |  corpus=surface
   |  akaza =got
   Good count=X bad count=Y elapsed=Zms saigen=W
```

## 変更後
```
[BAD] yomi => corpus=surface, akaza=got
Good count=X bad count=Y elapsed=Zms saigen=W
```

## Test plan

- [x] `cargo build --package akaza-data` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)