### PR TITLE
check: stdin からの複数行入力に対応

### DIFF
--- a/akaza-data/README.md
+++ b/akaza-data/README.md
@@ -13,11 +13,15 @@ cargo build --package akaza-data --release
 ### check - かな漢字変換を実行する
 
 ひらがな文字列をかな漢字変換して結果を表示します。
+引数を省略すると stdin から行ごとに読み取ります（エンジンを1回だけ構築して複数行を処理できます）。
 
 ```bash
 # 基本的な使い方（設定ファイルのデフォルト設定を使用）
 akaza-data check きょうはいいてんきですね
 # => 今日/は/いい/天気/です/ね
+
+# stdin から複数行を処理
+echo -e "きょうはいいてんきですね\nわたしはにほんごがすきです" | akaza-data check
 
 # JSON 出力
 akaza-data check --format json きょうはいいてんきですね

--- a/akaza-data/src/main.rs
+++ b/akaza-data/src/main.rs
@@ -170,8 +170,8 @@ struct LearnCorpusArgs {
 /// かな漢字変換を実行する（CLI テスト用）
 #[derive(Debug, clap::Args)]
 struct CheckArgs {
-    /// 変換したい読みがな
-    yomi: String,
+    /// 変換したい読みがな（省略時は stdin から行ごとに読み取る）
+    yomi: Option<String>,
     /// 期待する変換結果（指定すると DOT グラフを出力）
     expected: Option<String>,
     /// ユーザーデータ（学習データ）を使用する
@@ -285,7 +285,7 @@ fn main() -> anyhow::Result<()> {
             opts.dst_bigram.as_str(),
         ),
         Commands::Check(opt) => check(CheckOptions {
-            yomi: &opt.yomi,
+            yomi: opt.yomi,
             expected: opt.expected,
             use_user_data: opt.user_data,
             eucjp_dict: &opt.eucjp_dict,


### PR DESCRIPTION
## Summary

`check` コマンドの `yomi` 引数を省略可能にし、省略時は stdin から行ごとに読み取るようにした。
これにより、エンジンを1回だけ構築して複数行をまとめて処理できる。

## 変更内容

- `CheckArgs.yomi` を `String` → `Option<String>` に変更
- `CheckOptions.yomi` を `&str` → `Option<String>` に変更
- エンジン構築後の変換処理を `check_one_line()` 関数に分離
- `yomi` が `Some` の場合: 従来通り1行処理（`expected` / DOT 出力も使える）
- `yomi` が `None` の場合: stdin から行ごとに処理（空行はスキップ）
- README に stdin からの入力例を追加

## 使い方

```bash
# 引数指定（従来通り）
akaza-data check きょうはいいてんきですね

# stdin から複数行
echo -e "きょうはいいてんきですね\nわたしはにほんごがすきです" | akaza-data check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)