### PR TITLE
segmenter: unwrap() を除去し空文字列でのクラッシュを防止

### DIFF
--- a/libakaza/src/graph/segmenter.rs
+++ b/libakaza/src/graph/segmenter.rs
@@ -165,7 +165,10 @@ impl Segmenter {
 
                 trace!("There's no candidates. '{}'", yomi);
 
-                let (_, c) = yomi.char_indices().next().unwrap();
+                let Some((_, c)) = yomi.char_indices().next() else {
+                    warn!("Empty yomi in segmentation at start_pos={}", start_pos);
+                    continue;
+                };
                 let first = &yomi[0..c.len_utf8()];
                 let ends_at = start_pos + first.len();
 


### PR DESCRIPTION
## Summary

segmenter.rs L168 の `yomi.char_indices().next().unwrap()` を `let Some(...) = ... else` パターンに変更し、空文字列でのクラッシュリスクを除去しました。

## 変更内容

- `yomi.char_indices().next().unwrap()` → `let Some((_, c)) = yomi.char_indices().next() else { warn!(...); continue; }` に変更
- L119 の `yomi.is_empty()` ガードがあるため通常は到達しないが、安全のため防御的に処理

## テスト結果

```
running 4 tests
test graph::segmenter::tests::test_simple ... ok
test graph::segmenter::tests::test_force ... ok
test graph::segmenter::tests::test_number ... ok
test graph::segmenter::tests::test_without_kanatrie ... ok
```

Related: #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)