### PR TITLE
変換の速度/品質トレードオフを config から調整可能にする

### DIFF
--- a/akaza-conf/src/conf.rs
+++ b/akaza-conf/src/conf.rs
@@ -69,6 +69,7 @@ fn connect_activate(app: &Application, config: Arc<Mutex<Config>>) -> Result<()>
                 dicts: config.engine.dicts.clone(),
                 dict_cache: true,
                 reranking_weights: config.engine.reranking_weights.clone(),
+                convert_k: config.engine.convert_k,
             },
         };
         info!("Saving config: {}", serde_yaml::to_string(&config).unwrap());

--- a/akaza-data/src/subcmd/evaluate.rs
+++ b/akaza-data/src/subcmd/evaluate.rs
@@ -134,6 +134,8 @@ pub fn evaluate(
         model: model_dir,
         dict_cache: false,
         reranking_weights,
+        // evaluate は convert_k_best を直接呼ぶため convert_k は未使用。既定値で埋める。
+        convert_k: 10,
     };
 
     // コーパスの全行を事前に読み込む

--- a/libakaza/src/config.rs
+++ b/libakaza/src/config.rs
@@ -55,6 +55,7 @@ fn default_engine_config() -> EngineConfig {
         dict_cache: true,
         model: default_model(),
         reranking_weights: ReRankingWeights::default(),
+        convert_k: default_convert_k(),
     }
 }
 
@@ -149,10 +150,20 @@ pub struct EngineConfig {
     /// リランキング重み（省略時はデフォルト値 = 従来と同じ挙動）
     #[serde(default)]
     pub reranking_weights: ReRankingWeights,
+
+    /// convert() で評価する k-best パス数。
+    /// 大きいほど候補パターンは増えるが変換が遅くなる（速度/品質のトレードオフ）。
+    /// 省略時は 10（従来と同じ挙動）。
+    #[serde(default = "default_convert_k")]
+    pub convert_k: usize,
 }
 
 fn default_dict_cache() -> bool {
     true
+}
+
+fn default_convert_k() -> usize {
+    10
 }
 
 fn default_model() -> String {

--- a/libakaza/src/engine/bigram_word_viterbi_engine.rs
+++ b/libakaza/src/engine/bigram_word_viterbi_engine.rs
@@ -33,6 +33,8 @@ pub struct BigramWordViterbiEngine<U: SystemUnigramLM, B: SystemBigramLM, KD: Ka
     pub user_data: Arc<Mutex<UserData>>,
     reranking_weights: ReRankingWeights,
     skip_bigram_lm: Option<Rc<MarisaSystemSkipBigramLM>>,
+    /// convert() で評価する k-best パス数（config 由来）
+    convert_k: usize,
 }
 
 impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Debug
@@ -59,8 +61,8 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> HenkanEngine
         force_ranges: Option<&[Range<usize>]>,
     ) -> Result<Vec<Vec<Candidate>>> {
         // リランキングを適用するため、k-best で複数パスを取得してリランキング
-        // k=10 で十分な候補パターンを取得し、リランキング後の最良パスを返す
-        let paths = self.convert_k_best(yomi, force_ranges, 10)?;
+        // k は config 由来（convert_k）。大きいほど候補は増えるが遅くなる
+        let paths = self.convert_k_best(yomi, force_ranges, self.convert_k)?;
         if let Some(best_path) = paths.first() {
             Ok(best_path.segments.clone())
         } else {
@@ -232,6 +234,7 @@ impl BigramWordViterbiEngineBuilder {
             user_data,
             reranking_weights,
             skip_bigram_lm,
+            convert_k: self.config.convert_k,
         })
     }
 
@@ -317,6 +320,7 @@ mod tests {
             user_data: Arc::new(Mutex::new(UserData::default())),
             reranking_weights: ReRankingWeights::default(),
             skip_bigram_lm: None,
+            convert_k: 10,
         };
 
         // convert を呼び出し（リランキング適用済み）
@@ -389,6 +393,7 @@ mod tests {
             user_data: Arc::new(Mutex::new(UserData::default())),
             reranking_weights: ReRankingWeights::default(),
             skip_bigram_lm: None,
+            convert_k: 10,
         };
 
         // to_lattice → resolve を呼び出し（リランキングなし）

--- a/libakaza/src/graph/graph_resolver.rs
+++ b/libakaza/src/graph/graph_resolver.rs
@@ -170,7 +170,8 @@ impl GraphResolver {
                     if let Some(prev_entries) = kbest_map.get(prev) {
                         for (rank, prev_entry) in prev_entries.iter().enumerate() {
                             // skip-bigram: 祖父ノード (prev_entry.prev_node) と現在ノード (node)
-                            let skip_cost = if !is_eos {
+                            // 重みが 0 のときは DP・rerank 双方への寄与が 0 なので trie lookup を省略する
+                            let skip_cost = if !is_eos && self.skip_bigram_weight != 0.0 {
                                 self.skip_bigram_cost(prev_entry.prev_node, node, &user_data)
                             } else {
                                 0.0


### PR DESCRIPTION
## Summary

かな漢字変換の速度/品質のトレードオフを、アプリ（mac-akaza / ibus-akaza）側の `config.yml` から調整できるようにする。デフォルト挙動は従来どおりで変更なし。

背景: 長文変換の体感速度を調査したところ、本番設定 (k=10) では **skip-bigram が変換時間の約36%** を占めていた。さらに k-best のパス数 k 自体が遅さの最大要因だが、これまで `convert()` 内で 10 にハードコードされており外から変えられなかった。そこで「速度を優先したいアプリが自分でノブを回せる」状態にする。

## 変更内容

### 1. `convert_k` を `EngineConfig` に追加
- これまで `convert()` 内で 10 ハードコードだった k-best パス数を config 化。
- `#[serde(default)]` で省略時は 10。従来挙動を完全に維持。
- アプリが下げれば変換が概ね線形に高速化する（実測 k=10→5 で avg 95→51ms）。

### 2. `skip_bigram_weight == 0.0` で skip-bigram lookup を短絡
- `skip_bigram_weight` は既に config にあったが、重みが 0 でも skip-bigram コストを計算してから ×0 していたため、0 にしても速くならなかった。
- weight が 0 のとき trie lookup 自体を省略するように修正。DP・rerank 双方への寄与が 0 なので結果は不変。
- これで「重み 0 = skip-bigram オフ」が実効的な速度ノブになる。

### 設定例（速度優先）
\`\`\`yaml
engine:
  convert_k: 5
  reranking_weights:
    skip_bigram_weight: 0.0
\`\`\`

## テスト結果

- `cargo test -p libakaza --lib`: 124 passed / 0 failed
- `cargo fmt --check`, `cargo clippy`（pre-commit hook 含む）: OK
- 短絡の効果を同一条件（同モデル・k=10、`skip_bigram_weight` のみ変更）で実測:
  - `skip_bigram_weight: 0.2` → avg 18.5ms, p99 94.9ms
  - `skip_bigram_weight: 0.0` → avg 4.0ms, p99 17.9ms （約 4.6 倍速）

## 注意

- デフォルト値（`convert_k=10`, `skip_bigram_weight=0.2`）は不変のため品質退行はなし。
- アプリ側で k を下げる / skip 重みを 0 にする場合は、その設定で `make evaluate` の再現率を確認することを推奨。