### PR TITLE
長文変換を高速化: skip-bigram コスト計算のボトルネック解消

### DIFF
--- a/akaza-data/src/subcmd/learn_corpus.rs
+++ b/akaza-data/src/subcmd/learn_corpus.rs
@@ -64,13 +64,13 @@ impl LearningService {
                 let corpuses = read_corpus_file(Path::new(fname))?;
                 for corpus in corpuses {
                     for node in corpus.nodes {
-                        if !unigram_map.contains_key(node.key().as_str()) {
+                        if !unigram_map.contains_key(node.key()) {
                             info!(
                                 "Insert missing element: {} max_id={}",
                                 node.key(),
                                 max_id + 1
                             );
-                            unigram_map.insert(node.key(), (max_id + 1, 1));
+                            unigram_map.insert(node.key().to_string(), (max_id + 1, 1));
                             max_id += 1;
                         }
                     }
@@ -188,11 +188,8 @@ impl LearningService {
             if !teacher.nodes.is_empty() {
                 for i in 0..teacher.nodes.len() {
                     let key = teacher.nodes[i].key();
-                    let (_, cost) = self
-                        .system_unigram_lm
-                        .find_cnt(&key.to_string())
-                        .unwrap_or((-1, 0_u32));
-                    self.system_unigram_lm.update(key.as_str(), cost - delta);
+                    let (_, cost) = self.system_unigram_lm.find_cnt(key).unwrap_or((-1, 0_u32));
+                    self.system_unigram_lm.update(key, cost - delta);
                 }
             }
 
@@ -201,10 +198,10 @@ impl LearningService {
                 for i in 1..teacher.nodes.len() {
                     let key1 = teacher.nodes[i - 1].key();
                     let key2 = teacher.nodes[i].key();
-                    let Some((word_id1, _)) = self.system_unigram_lm.find(key1.as_str()) else {
+                    let Some((word_id1, _)) = self.system_unigram_lm.find(key1) else {
                         continue;
                     };
-                    let Some((word_id2, _)) = self.system_unigram_lm.find(key2.as_str()) else {
+                    let Some((word_id2, _)) = self.system_unigram_lm.find(key2) else {
                         continue;
                     };
                     let v = self
@@ -225,10 +222,10 @@ impl LearningService {
                     for i in 2..teacher.nodes.len() {
                         let key1 = teacher.nodes[i - 2].key();
                         let key2 = teacher.nodes[i].key();
-                        let Some((word_id1, _)) = self.system_unigram_lm.find(key1.as_str()) else {
+                        let Some((word_id1, _)) = self.system_unigram_lm.find(key1) else {
                             continue;
                         };
-                        let Some((word_id2, _)) = self.system_unigram_lm.find(key2.as_str()) else {
+                        let Some((word_id2, _)) = self.system_unigram_lm.find(key2) else {
                             continue;
                         };
                         let v = skip_bigram_lm
@@ -248,7 +245,7 @@ impl LearningService {
                 // BOS → 最初の単語
                 if let Some((bos_id, _)) = self.system_unigram_lm.find(BOS_TOKEN_KEY) {
                     let first_key = teacher.nodes[0].key();
-                    if let Some((first_id, _)) = self.system_unigram_lm.find(first_key.as_str()) {
+                    if let Some((first_id, _)) = self.system_unigram_lm.find(first_key) {
                         let v = self
                             .system_bigram_lm
                             .get_edge_cnt(bos_id, first_id)
@@ -263,7 +260,7 @@ impl LearningService {
                 // 最後の単語 → EOS
                 if let Some((eos_id, _)) = self.system_unigram_lm.find(EOS_TOKEN_KEY) {
                     let last_key = teacher.nodes.last().unwrap().key();
-                    if let Some((last_id, _)) = self.system_unigram_lm.find(last_key.as_str()) {
+                    if let Some((last_id, _)) = self.system_unigram_lm.find(last_key) {
                         let v = self
                             .system_bigram_lm
                             .get_edge_cnt(last_id, eos_id)

--- a/libakaza/src/graph/graph_resolver.rs
+++ b/libakaza/src/graph/graph_resolver.rs
@@ -144,6 +144,13 @@ impl GraphResolver {
         // user_data のロックを一度だけ取得し、ループ中は保持する
         let user_data = lattice.lock_user_data();
 
+        // skip-bigram コストのメモ化キャッシュ。skip_cost は (祖父, 現ノード) のみに依存し、
+        // 現ノードは外側ループで固定なので、祖父ノードのポインタをキーにすればよい。
+        // 各ノードの処理開始時に clear する。
+        // k-best では1つの prev の k 本のパスが同じ祖父を共有することが多く、
+        // ここで String 構築・数字正規化・trie lookup の重複を排除できる。
+        let mut skip_cache: FxHashMap<usize, f32> = FxHashMap::default();
+
         // 前向きに動的計画法でたどる
         for i in 1..yomi.len() + 2 {
             let Some(nodes) = &lattice.node_list(i as i32) else {
@@ -162,6 +169,8 @@ impl GraphResolver {
 
                 // 各前ノードの k-best エントリそれぞれについて候補を生成
                 let is_eos = node.surface == "__EOS__";
+                let compute_skip = !is_eos && self.skip_bigram_weight != 0.0;
+                skip_cache.clear();
                 let mut entries: Vec<KBestEntry> = Vec::with_capacity(k * prev_nodes.len());
                 for prev in prev_nodes {
                     let (edge_cost, is_known_bigram) =
@@ -171,8 +180,11 @@ impl GraphResolver {
                         for (rank, prev_entry) in prev_entries.iter().enumerate() {
                             // skip-bigram: 祖父ノード (prev_entry.prev_node) と現在ノード (node)
                             // 重みが 0 のときは DP・rerank 双方への寄与が 0 なので trie lookup を省略する
-                            let skip_cost = if !is_eos && self.skip_bigram_weight != 0.0 {
-                                self.skip_bigram_cost(prev_entry.prev_node, node, &user_data)
+                            let skip_cost = if compute_skip {
+                                let gp_key = prev_entry.prev_node as *const WordNode as usize;
+                                *skip_cache.entry(gp_key).or_insert_with(|| {
+                                    self.skip_bigram_cost(prev_entry.prev_node, node, &user_data)
+                                })
                             } else {
                                 0.0
                             };
@@ -1128,6 +1140,83 @@ mod tests {
             .map(|c| c[0].surface.clone())
             .collect();
         assert_eq!(single_surfaces, kbest_surfaces);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_skip_bigram_cost_accumulated_with_memoization() -> anyhow::Result<()> {
+        // skip-bigram LM を有効にした状態で、best パスに (w_{i-2}, w_i) の
+        // skip-bigram コストが正しく蓄積されることを確認する。
+        // メモ化（祖父ノード単位のキャッシュ）を導入しても結果が変わらないことの回帰テスト。
+        use crate::kana_trie::cedarwood_kana_trie::CedarwoodKanaTrie;
+        use crate::lm::system_skip_bigram::MarisaSystemSkipBigramLMBuilder;
+
+        let kana_trie =
+            CedarwoodKanaTrie::build(vec!["わ".to_string(), "た".to_string(), "し".to_string()]);
+        let segmenter = Segmenter::new(vec![Arc::new(Mutex::new(kana_trie))]);
+        let graph = segmenter.build("わたし", None);
+
+        let dict = HashMap::from([
+            ("わ".to_string(), vec!["和".to_string()]),
+            ("た".to_string(), vec!["田".to_string()]),
+            ("し".to_string(), vec!["詩".to_string()]),
+        ]);
+
+        let mut unigram_builder = MarisaSystemUnigramLMBuilder::default();
+        unigram_builder.add("和/わ", 1.0);
+        unigram_builder.add("田/た", 1.0);
+        unigram_builder.add("詩/し", 1.0);
+        unigram_builder.set_total_words(100);
+        unigram_builder.set_unique_words(50);
+        let system_unigram_lm = unigram_builder.build()?;
+
+        let unigram_map = system_unigram_lm.as_hash_map();
+        let wa_id = unigram_map.get("和/わ").unwrap().0;
+        let shi_id = unigram_map.get("詩/し").unwrap().0;
+
+        let system_bigram_lm = MarisaSystemBigramLMBuilder::default()
+            .set_default_edge_cost(1.0)
+            .build()?;
+
+        // skip-bigram: (和, 詩) = w_{i-2}, w_i に明示コストを与える。
+        let mut skip_builder = MarisaSystemSkipBigramLMBuilder::default();
+        skip_builder.add(wa_id, shi_id, 2.5);
+        skip_builder.set_default_skip_cost(9.0);
+        let skip_lm = skip_builder.build()?;
+
+        let graph_builder = GraphBuilder::new(
+            HashmapVecKanaKanjiDict::new(dict),
+            HashmapVecKanaKanjiDict::new(HashMap::new()),
+            Arc::new(Mutex::new(UserData::default())),
+            Rc::new(system_unigram_lm),
+            Rc::new(system_bigram_lm),
+        );
+        let lattice = graph_builder.construct("わたし", &graph);
+
+        let resolver = GraphResolver::new(Some(Rc::new(skip_lm)), 1.0);
+        let paths = resolver.resolve_k_best(&lattice, 5)?;
+
+        // 和/田/詩 (3トークン) のパスを探す。
+        let target = paths
+            .iter()
+            .find(|p| {
+                let s: Vec<String> = p
+                    .segments
+                    .iter()
+                    .filter_map(|seg| seg.first().map(|c| c.surface.clone()))
+                    .collect();
+                s == ["和", "田", "詩"]
+            })
+            .expect("和/田/詩 path should exist");
+
+        // skip ペアは (BOS, 田) と (和, 詩)。BOS は word_id 未設定なので 0.0。
+        // よって skip_bigram_cost ≈ skip(和, 詩) = 2.5（f16 丸め誤差を許容）。
+        assert!(
+            (target.skip_bigram_cost - 2.5).abs() < 0.05,
+            "expected skip_bigram_cost ~2.5, got {}",
+            target.skip_bigram_cost
+        );
 
         Ok(())
     }

--- a/libakaza/src/graph/word_node.rs
+++ b/libakaza/src/graph/word_node.rs
@@ -14,6 +14,9 @@ pub struct WordNode {
     pub cost: f32,
     pub word_id_and_score: Option<(i32, f32)>,
     pub auto_generated: bool,
+    /// LM 参照用の `surface/yomi` キー。生成時に1度だけ構築してキャッシュする
+    /// （Viterbi DP の最内ループで毎回 alloc するのを避けるため）。
+    key: String,
 }
 
 impl Hash for WordNode {
@@ -37,11 +40,16 @@ impl PartialEq<Self> for WordNode {
 impl Eq for WordNode {}
 
 impl WordNode {
-    pub fn key(&self) -> String {
-        let mut buf = String::new();
-        buf += self.surface.as_str();
-        buf += "/";
-        buf += self.yomi.as_str();
+    /// LM 参照用の `surface/yomi` キー。生成時にキャッシュ済みの値を返す。
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    fn build_key(surface: &str, yomi: &str) -> String {
+        let mut buf = String::with_capacity(surface.len() + 1 + yomi.len());
+        buf.push_str(surface);
+        buf.push('/');
+        buf.push_str(yomi);
         buf
     }
 
@@ -53,6 +61,7 @@ impl WordNode {
             cost: 0_f32,
             word_id_and_score: None,
             auto_generated: true,
+            key: BOS_TOKEN_KEY.to_string(),
         }
     }
     pub(crate) fn create_eos(start_pos: i32) -> WordNode {
@@ -63,6 +72,7 @@ impl WordNode {
             cost: 0_f32,
             word_id_and_score: None,
             auto_generated: true,
+            key: EOS_TOKEN_KEY.to_string(),
         }
     }
     pub fn new(
@@ -84,6 +94,7 @@ impl WordNode {
             cost: 0_f32,
             word_id_and_score,
             auto_generated,
+            key: Self::build_key(surface, yomi),
         }
     }
 }
@@ -91,5 +102,31 @@ impl WordNode {
 impl Display for WordNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.surface, self.yomi)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_cached() {
+        let node = WordNode::new(0, "私", "わたし", None, false);
+        assert_eq!(node.key(), "私/わたし");
+        // 何度呼んでも同じ値（キャッシュ済み）
+        assert_eq!(node.key(), "私/わたし");
+    }
+
+    #[test]
+    fn test_key_bos_eos() {
+        assert_eq!(WordNode::create_bos().key(), BOS_TOKEN_KEY);
+        assert_eq!(WordNode::create_eos(3).key(), EOS_TOKEN_KEY);
+    }
+
+    #[test]
+    fn test_key_survives_clone() {
+        let node = WordNode::new(0, "天気", "てんき", None, false);
+        let cloned = node.clone();
+        assert_eq!(cloned.key(), "天気/てんき");
     }
 }

--- a/libakaza/src/user_side_data/bigram_user_stats.rs
+++ b/libakaza/src/user_side_data/bigram_user_stats.rs
@@ -35,6 +35,12 @@ impl BiGramUserStats {
      * システム言語モデルのコストよりも安くなるように調整してある。
      */
     pub(crate) fn get_cost(&self, key1: &str, key2: &str) -> Option<f32> {
+        // ユーザー統計が空なら、キー構築・数字正規化を行わず即座に None を返す。
+        // Viterbi DP のエッジ評価から呼ばれるため、空マップ時の無駄な alloc/パースを避ける。
+        if self.word_count.is_empty() {
+            return None;
+        }
+
         let mut key = String::with_capacity(key1.len() + 1 + key2.len());
         key.push_str(key1);
         key.push('\t');

--- a/libakaza/src/user_side_data/skip_bigram_user_stats.rs
+++ b/libakaza/src/user_side_data/skip_bigram_user_stats.rs
@@ -30,6 +30,12 @@ impl SkipBigramUserStats {
 
     /// skip-bigram のエッジコストを計算する。
     pub(crate) fn get_cost(&self, key1: &str, key2: &str) -> Option<f32> {
+        // ユーザー統計が空なら、キー構築・数字正規化を行わず即座に None を返す。
+        // Viterbi DP の最内ループから呼ばれるため、空マップ時の無駄な alloc/パースを避ける。
+        if self.word_count.is_empty() {
+            return None;
+        }
+
         let mut key = String::with_capacity(key1.len() + 1 + key2.len());
         key.push_str(key1);
         key.push('\t');
@@ -131,5 +137,27 @@ mod tests {
         let mut stats = SkipBigramUserStats::default();
         stats.record_entries(&[]);
         assert_eq!(stats.total_words, 0);
+    }
+
+    #[test]
+    fn test_get_cost_empty_returns_none() {
+        // 空マップでは（数字キーであっても）即 None を返す。
+        let stats = SkipBigramUserStats::default();
+        assert_eq!(stats.get_cost("私/わたし", "本/ほん"), None);
+        assert_eq!(stats.get_cost("1日/1にち", "後/ご"), None);
+    }
+
+    #[test]
+    fn test_get_cost_hit_after_record() {
+        let mut stats = SkipBigramUserStats::default();
+        stats.record_entries(&[
+            Candidate::new("きょう", "今日", 0.0),
+            Candidate::new("は", "は", 0.0),
+            Candidate::new("いい", "良い", 0.0),
+        ]);
+        // 今日 → 良い の skip-bigram が記録されているのでコストが返る。
+        assert!(stats.get_cost("今日/きょう", "良い/いい").is_some());
+        // 未登録ペアは None。
+        assert_eq!(stats.get_cost("今日/きょう", "悪い/わるい"), None);
     }
 }

--- a/libakaza/src/user_side_data/user_data.rs
+++ b/libakaza/src/user_side_data/user_data.rs
@@ -371,17 +371,16 @@ impl UserData {
     }
 
     pub fn get_unigram_cost(&self, node: &WordNode) -> Option<f32> {
-        self.unigram_user_stats.get_cost(&node.key())
+        self.unigram_user_stats.get_cost(node.key())
     }
 
     pub fn get_bigram_cost(&self, node1: &WordNode, node2: &WordNode) -> Option<f32> {
-        self.bigram_user_stats
-            .get_cost(node1.key().as_str(), node2.key().as_str())
+        self.bigram_user_stats.get_cost(node1.key(), node2.key())
     }
 
     pub fn get_skip_bigram_cost(&self, node1: &WordNode, node2: &WordNode) -> Option<f32> {
         self.skip_bigram_user_stats
-            .get_cost(node1.key().as_str(), node2.key().as_str())
+            .get_cost(node1.key(), node2.key())
     }
 }
 


### PR DESCRIPTION
## Summary

長文変換の速度を改善する（Related: #559、目標 200ms 以下）。profiling で、長文変換時間の約 **60%** が Viterbi DP 内の skip-bigram コスト計算に費やされていることを特定し、3点で解消した。**いずれも変換結果は bit-exact**（出力は変更前と完全一致）なので品質退行はない。

> [!NOTE]
> このブランチは #558 の `skip_bigram_weight != 0.0` 短絡を前提にしているため、#558 をベースにしたスタック PR です。

## profiling 結果

`perf record`（60回変換、31012サンプル）で計測:

```
resolve_k_best (Viterbi DP)                         86.5%
└─ skip_bigram_cost                  72.6% of DP   ≈ 全体の約60%
   ├─ UserData::get_skip_bigram_cost  41%  ← String alloc + 数字正規化
   └─ MarisaSystemSkipBigramLM::get_skip_cost  31%  ← trie lookup
```

`skip_bigram_cost(祖父, 現ノード)` が DP 最内ループで O(エッジ数 × k) 回呼ばれ、1回ごとに `WordNode::key()` の String alloc ×2・キー連結・`normalize_counter_key_for_lm`（数字パース）・trie lookup を行っていた。

## 変更内容

- **A** (`graph_resolver.rs`): `resolve_k_best` の最内ループで `skip_bigram_cost(祖父, 現ノード)` を**祖父ノードのポインタ単位でメモ化**。現ノードは外側ループで固定なので祖父ポインタだけをキーにすればよく、各ノードの処理開始時に clear する。k-best の k 本のパスが同じ祖父を共有することが多く、重複計算を排除できる。
- **B** (`word_node.rs`): `WordNode` 生成時に `surface/yomi` の LM キーを**1度だけ構築してフィールド保持**し、`key()` を `&str` 返却に変更。DP 最内ループの String alloc を全廃（呼び出し元の `user_data.rs` / `learn_corpus.rs` も追従）。
- **C** (`skip_bigram_user_stats.rs` / `bigram_user_stats.rs`): ユーザー統計が空なら `get_cost` で即 `None` を返し、キー構築・数字正規化を回避。

## 実測（26文字「じっさいにこのぐらいながいとおそいとかんじるんだよな」、k=10/skip重み0.2 デフォルト）

| 条件 | BEFORE | AFTER | 改善 |
|------|--------|-------|------|
| ユーザーデータなし | 383.8ms | **54.0ms** | **約7.1倍** |
| `-u`（本番相当） | 378.5ms | **68.4ms** | **約5.5倍** |

いずれも目標の 200ms 以下を達成。

## テスト結果

- `cargo test -p libakaza --lib`: **130 passed**（新規6件追加）/ 0 failed
- `cargo test -p akaza-data`: **41 passed** / 0 failed
- `cargo fmt --check`, `cargo clippy`（pre-commit hook 含む）: OK
- **bit-exact 検証**: `akaza-data check -k1/-k5 -f json` の出力が `-u` 有無とも変更前と完全一致（→ `make evaluate` の再現率も原理的に不変）

新規テスト:
- `WordNode::key()` のキャッシュ・BOS/EOS・clone 保持
- skip-bigram LM 有効時にメモ化下で skip コストが正しく蓄積されることの回帰テスト
- 空マップ短絡と記録後ヒットの検証