### PR TITLE
エンジン起動時間を 7s → 200ms に短縮

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "akaza-conf"
-version = "2026.404.0"
+version = "2026.530.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "akaza-data"
-version = "2026.404.0"
+version = "2026.530.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "akaza-dict"
-version = "2026.404.0"
+version = "2026.530.0"
 dependencies = [
  "anyhow",
  "encoding_rs",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "ibus-akaza"
-version = "2026.404.0"
+version = "2026.530.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "ibus-sys"
-version = "2026.404.0"
+version = "2026.530.0"
 dependencies = [
  "log",
 ]
@@ -1162,7 +1162,7 @@ checksum = "70048d97b51d107a6cf295d42210d298f0eb7d37f0518b88c816a74b8ce15f41"
 
 [[package]]
 name = "libakaza"
-version = "2026.404.0"
+version = "2026.530.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1551,9 +1551,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rsmarisa"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb8faa8d19e79a31e62e7856e16cd5c2d8ba71629910ce3ba1db287f968954d"
+checksum = "a7490d7079b13206bb94e7973473580585d466038ed3b1b8ccd06f88eb5bba69"
 dependencies = [
  "clap",
  "memmap2",

--- a/akaza-data/Cargo.toml
+++ b/akaza-data/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "0.4"
 vibrato = "0.5.2"
 walkdir = "2"
 rayon = "1.10"
-rsmarisa = "0.4.0"
+rsmarisa = "0.4.2"
 redb = "2"
 rustc-hash = "2"
 serde = { version = "1.0", features = ["derive"] }

--- a/akaza-data/src/main.rs
+++ b/akaza-data/src/main.rs
@@ -302,6 +302,10 @@ struct BenchArgs {
     /// k-best のパス数
     #[arg(short, long, default_value_t = 5)]
     k: usize,
+    /// dict cache (~/.cache/akaza/) を使う。デフォルトはユーザー環境を汚さないため off。
+    /// 起動時間を計測するときは on にすること。
+    #[arg(long)]
+    dict_cache: bool,
 }
 
 /// ユニグラム辞書ファイルをダンプする
@@ -450,6 +454,7 @@ fn main() -> anyhow::Result<()> {
             model_dir: opt.model_dir.as_deref(),
             max_sentences: opt.max_sentences,
             k: opt.k,
+            dict_cache: opt.dict_cache,
         }),
         Commands::DumpUnigramDict(opt) => dump_unigram_dict(opt.dict.as_str()),
         Commands::DumpBigramDict(opt) => {

--- a/akaza-data/src/subcmd/bench.rs
+++ b/akaza-data/src/subcmd/bench.rs
@@ -15,6 +15,7 @@ pub struct BenchOptions<'a> {
     pub utf8_dict: &'a [String],
     pub max_sentences: usize,
     pub k: usize,
+    pub dict_cache: bool,
 }
 
 /// インクリメンタル変換のベンチマークを実行する。
@@ -46,7 +47,7 @@ pub fn bench(opts: BenchOptions) -> anyhow::Result<()> {
         });
     }
 
-    config.engine.dict_cache = false;
+    config.engine.dict_cache = opts.dict_cache;
 
     // --- エンジン構築 ---
     let engine_t1 = Instant::now();
@@ -84,6 +85,22 @@ pub fn bench(opts: BenchOptions) -> anyhow::Result<()> {
     println!("Loaded {} sentences from corpus", sentences.len());
     println!("---");
 
+    // --- cold/warm latency 検証: 最長文を 5 回連続で変換して per-call を出す ---
+    if let Some(longest) = sentences.iter().max_by_key(|s| s.chars().count()) {
+        let chars: Vec<char> = longest.chars().collect();
+        let full: String = chars.iter().collect();
+        println!("Cold/warm probe — {} ({} chars) x5", longest, chars.len());
+        let mut pc: Vec<f64> = Vec::new();
+        for _ in 0..5 {
+            let t = Instant::now();
+            let _ = engine.convert_k_best(&full, None, opts.k)?;
+            pc.push(t.elapsed().as_micros() as f64 / 1000.0);
+        }
+        let pc_str: Vec<String> = pc.iter().map(|x| format!("{:.1}", x)).collect();
+        println!("  per-iter (ms): [{}]", pc_str.join(", "));
+        println!("---");
+    }
+
     // --- ベンチマーク実行 ---
     let mut all_durations_us: Vec<u64> = Vec::new();
 
@@ -117,6 +134,13 @@ pub fn bench(opts: BenchOptions) -> anyhow::Result<()> {
             num_chars,
             num_chars
         );
+        if i == 0 {
+            let per_call: Vec<String> = sentence_durations_us
+                .iter()
+                .map(|us| format!("{:.1}", *us as f64 / 1000.0))
+                .collect();
+            println!("          per-call (ms): [{}]", per_call.join(", "));
+        }
         println!(
             "          avg={:.1}ms, max={:.1}ms, total={:.1}ms",
             avg_us / 1000.0,

--- a/docs/src/internals/notes/performance-investigation-2026-02.md
+++ b/docs/src/internals/notes/performance-investigation-2026-02.md
@@ -191,3 +191,136 @@ trie キーからスコア (f16) を除去し、スコアは `key_id` をイン�
 - 値の外部配列化による trie サイズ変化の実測
 - select 高速化の実効果
 - エントリ数削減（低頻度 bigram の枝刈り）の影響
+
+---
+
+# rsmarisa チューニング (2026-06-01)
+
+`akaza-data bench`（`anthy-corpus/corpus.3.txt`, 50文, k=5）と perf -F 997 で計測。
+ローカル rsmarisa を `[patch.crates-io] rsmarisa = { path = "../rsmarisa" }` で参照。
+
+## ベンチ結果（best of 3）
+
+| 指標 | baseline (rsmarisa 0.4.0) | 最適化後 |
+|---|---|---|
+| avg | 5.4–5.5 ms | 5.2–5.3 ms |
+| median | 3.5 ms | 3.3–3.5 ms |
+| p95 | 18.2–18.5 ms | 17.2–17.8 ms |
+| p99 | 30.1–30.4 ms | 29.2–29.7 ms |
+| max | 40.3–40.7 ms | 38.4–40.9 ms |
+
+おおむね 2–5% の改善。
+
+## perf self-time 内訳（cpu_core, 300文）
+
+| 関数 | baseline | 最適化後 | 差 |
+|---|---|---|---|
+| `LoudsTrie::find_child` | 16.37% | 14.53% | -1.84pp |
+| `LoudsTrie::match_` | 6.10% | 5.98% | -0.12pp |
+| `LoudsTrie::prefix_match_` | 2.52% | 2.31% | -0.21pp |
+| `BitVector::select0` | 2.67% | 2.11% | -0.56pp |
+| `LoudsTrie::predictive_search` | 1.97% | 1.90% | -0.07pp |
+| `LoudsTrie::restore_` | 1.63% | 1.69% | +0.06pp |
+| `BitVector::select1` | 1.38% | 1.02% | -0.36pp |
+| `BitVector::rank1` | 0.79% | 0.75% | -0.04pp |
+| **rsmarisa 合計** | **~33.4%** | **~30.3%** | **-3.1pp** |
+
+select0/select1 は PDEP 化が効いて約 20–26% 相対減。
+
+## 実施した最適化（rsmarisa 側）
+
+1. **PDEP ベースの `select_bit_u64`** — x86_64 で BMI2 を初回 `is_x86_feature_detected!`
+   で検出して以降キャッシュ。8 バイトのテーブルルックアップループ →
+   `_pdep_u64(1 << i, unit).trailing_zeros()` の 2-3 命令へ。
+2. **`assert!` → `debug_assert!`** — `BitVector::{get, rank0, rank1}`,
+   `State::{set_node_id, set_query_pos, set_history_pos}`, `LoudsTrie::{find_child,
+   predictive_find_child, match_, prefix_match_, restore_}` の冒頭境界チェック。
+   release ビルドの分岐数削減。
+3. **`Tail::match_tail` / `prefix_match` の Vec alloc 撤去** — それぞれ毎回
+   `agent.query().as_bytes().to_vec()` で 6 バイト程度の `Vec` を確保していた。
+   `Agent::query_bytes_and_state_mut()` の split-borrow ヘルパで `&[u8]` と
+   `&mut State` を同時に取れるようにし、ループ中の alloc/free を排除。
+4. **キャッシュエントリのローカルコピー** — `find_child` / `match_` /
+   `prefix_match_` / `restore_` / `predictive_find_child` の hot ループ内で
+   `self.cache[cache_id]` を 1 度ローカルにコピー（`Cache` は 12B Copy）。
+   `parent/child/extra/link/label` の連続アクセスでの再 indexing を抑える。
+
+いずれも結果は bit-exact（rsmarisa 全 323 ユニットテストが debug ビルドで pass、
+release ではプレ存在の `should_panic` テスト 3 件のみ失敗で、これは元から
+release で debug_assert が無効になることに依存していた既存のテストバグ）。
+
+## 残りのボトルネック
+
+- `find_child` の 14.5% は LOUDS の cache 照合 + 子ノード線形探索が支配的。
+  キャッシュサイズ（trie 構築時の `cache_level`）を上げると改善余地あり。
+- `resolve_k_best` 15.7%, quicksort 17%, sip::Hasher 2.2% は akaza 側 DP の
+  コスト。FxHashMap のはずなのに sip::Hasher が出ているのは要調査。
+- libc malloc/memmove で計 8% 前後。`resolve_k_best` の `Vec<KBestEntry>` 再確保
+  などが寄与している可能性。
+
+---
+
+# 起動時間短縮 (2026-06-01)
+
+`akaza-data bench --dict-cache` の `Engine built in Xms` 行で計測。
+
+## 起動時間の内訳
+
+| 段階 | 元 (warm) | cold | warm |
+|---|---|---|---|
+| unigram.model load | 7ms | 11ms | 7ms |
+| bigram.model + scores load | 154ms | 59〜64ms | 32ms |
+| skip_bigram.model + scores load | 254ms | 94〜104ms | 56ms |
+| dict load (cache hit) | 7ms | 12〜20ms | 6ms |
+| single_term | <1ms | <1ms | <1ms |
+| **kana_trie 構築** | **1069ms** | **3〜4ms** | **1.5〜1.7ms** |
+| **合計 (Engine built)** | **1490ms** | **188〜195ms** | **102〜104ms** |
+
+cold は `posix_fadvise(POSIX_FADV_DONTNEED)` で当該ファイルを page cache から
+追い出した状態。OS read のみで占められる下限値。
+
+## 実施した最適化
+
+### 1. `MarisaKanaTrie` の導入と cache 化（最大の効果）
+
+`CedarwoodKanaTrie` を毎起動 `dict.yomis()` (約 1M 件) + `single_term.yomis()`
+で `update()` していたのが起動時間の 70% 強を占めていた。同じ集合は変わらない
+データなので marisa-trie に build し `~/.cache/akaza/kana_trie_cache.marisa`
+として永続化、次回以降は `Trie::load` (約 2-4ms) で済むようにした。
+
+- 鮮度判定: `kana_trie_cache.marisa` の mtime が `kana_kanji_cache.marisa`
+  より古ければ再構築。dict 側 cache と同期する。
+- `dict_cache=false` のときは従来の cedarwood 経路にフォールバックし
+  cache ファイルを汚さない。
+- `KanaTrie` trait 実装で `Segmenter` への接続は変更不要。
+
+### 2. `.scores` ファイルの一括 read
+
+bigram (18M entry, 35MB) / skip_bigram (30M entry, 58MB) の `.scores` を
+2 バイトずつ `read_exact` + `push` する loop で読んでいた。`Vec<f16>` を
+1 回確保し、その underlying byte slice に対して 1 回の `read_exact` で埋める形
+に変更。`f16` (`#[repr(transparent)] u16`) と LE x86_64 の組み合わせで
+そのまま reinterpret 可能。
+
+### 3. bench へ `--dict-cache` フラグを追加
+
+bench は元々 `dict_cache=false` で動作していた（ユーザーの cache を汚さない）。
+起動時間を計測したいときだけ opt-in で有効化できるようにした。
+
+## 設計上のトレードオフ
+
+- **真の zero-copy mmap は採用しなかった**。rsmarisa の現在の `Trie::mmap()` は
+  mmap した領域から所有 Vec へ `copy_nonoverlapping` するので、純粋な
+  speed-up は load 経路をやや短縮する程度。一方 zero-copy 化には rsmarisa の
+  `Vector<T>` を「所有 / mmap 借用」の enum に作り変える必要があり、akaza 側で
+  目標 (500ms 以下) を満たすには A・B で十分だったため見送り。
+- **scores の `unsafe` は LE プラットフォーム前提**。BE arch をサポートする
+  必要が出たら portable な `chunks_exact + from_le_bytes` 経路に切り替える。
+
+## 残りの最適化余地
+
+- skip_bigram model+scores の load を std::thread で並列化すると 150-200ms 削れる
+  はず（今 cold で 100ms 強なので、`Engine built` を 100ms 切る目処）。
+- skip_bigram_weight=0 のときに skip_bigram の load 自体をスキップする
+  (lazy load)。convert 側で重み 0 のフォールバックは既に skip-bigram cost を
+  0 で扱う実装になっているため、`skip_bigram_lm: None` で動かせるはず。

--- a/libakaza/Cargo.toml
+++ b/libakaza/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rsmarisa = "0.4.0"
+rsmarisa = "0.4.2"
 chrono = "0.4"
 regex = "1"
 log = "0.4"

--- a/libakaza/src/engine/bigram_word_viterbi_engine.rs
+++ b/libakaza/src/engine/bigram_word_viterbi_engine.rs
@@ -17,7 +17,9 @@ use crate::graph::reranking::ReRankingWeights;
 use crate::graph::segmenter::Segmenter;
 use crate::kana_kanji::base::KanaKanjiDict;
 use crate::kana_kanji::marisa_kana_kanji_dict::MarisaKanaKanjiDict;
+use crate::kana_trie::base::KanaTrie;
 use crate::kana_trie::cedarwood_kana_trie::CedarwoodKanaTrie;
+use crate::kana_trie::marisa_kana_trie::MarisaKanaTrie;
 use crate::lm::base::{SystemBigramLM, SystemSkipBigramLM, SystemUnigramLM};
 use crate::lm::system_bigram::MarisaSystemBigramLM;
 use crate::lm::system_skip_bigram::MarisaSystemSkipBigramLM;
@@ -125,10 +127,17 @@ impl BigramWordViterbiEngineBuilder {
     > {
         let model_name = self.config.model.clone();
 
+        let t = std::time::Instant::now();
         let system_unigram_lm =
             MarisaSystemUnigramLM::load(Self::try_load(&model_name, "unigram.model")?.as_str())?;
+        info!("[startup] unigram.model loaded in {:?}", t.elapsed());
+
+        let t = std::time::Instant::now();
         let system_bigram_lm =
             MarisaSystemBigramLM::load(Self::try_load(&model_name, "bigram.model")?.as_str())?;
+        info!("[startup] bigram.model loaded in {:?}", t.elapsed());
+
+        let t = std::time::Instant::now();
         let skip_bigram_path = Self::try_load(&model_name, "skip_bigram.model")?;
         let skip_bigram_lm = match MarisaSystemSkipBigramLM::load(&skip_bigram_path) {
             Ok(lm) => {
@@ -143,6 +152,8 @@ impl BigramWordViterbiEngineBuilder {
                 None
             }
         };
+        info!("[startup] skip_bigram.model loaded in {:?}", t.elapsed());
+
         let system_dict = Self::try_load(&model_name, "SKK-JISYO.akaza")?;
 
         let user_data = if let Some(d) = &self.user_data {
@@ -151,6 +162,7 @@ impl BigramWordViterbiEngineBuilder {
             Arc::new(Mutex::new(UserData::default()))
         };
 
+        let t = std::time::Instant::now();
         let dict = {
             let mut dicts = self
                 .config
@@ -173,7 +185,9 @@ impl BigramWordViterbiEngineBuilder {
                 MarisaKanaKanjiDict::build(dict)?
             }
         };
+        info!("[startup] normal dict built in {:?}", t.elapsed());
 
+        let t = std::time::Instant::now();
         let single_term = {
             let dicts = self
                 .config
@@ -189,22 +203,60 @@ impl BigramWordViterbiEngineBuilder {
                 MarisaKanaKanjiDict::build(dict)?
             }
         };
+        info!("[startup] single_term dict built in {:?}", t.elapsed());
 
-        // 辞書を元に、トライを作成していく。
-        let mut kana_trie = CedarwoodKanaTrie::default();
-        for yomi in dict.yomis() {
-            assert!(!yomi.is_empty());
-            kana_trie.update(yomi.as_str());
-        }
-        for yomi in single_term.yomis() {
-            assert!(!yomi.is_empty());
-            kana_trie.update(yomi.as_str());
-        }
+        // 辞書を元に、共通接頭辞探索用の kana_trie を用意する。
+        //
+        // 過去は毎回 cedarwood に dict.yomis() 100 万件を update() で挿入していて、
+        // 起動時間の半分以上 (約 1 秒) を占めていた。kana_trie は dict と
+        // single_term の yomi 集合だけで決まる純粋データなので、marisa-trie
+        // にビルドして cache_name + ".kana.marisa" として永続化し、
+        // 次回以降は load (~ms) だけで済むようにする。
+        //
+        // 鮮度判定は dict_cache と同じソース(辞書ファイル)の mtime に従う。
+        // dict_cache_path より kana_trie cache が古ければ作り直す。
+        let t = std::time::Instant::now();
+        let kana_trie: Arc<Mutex<dyn KanaTrie>> = if self.config.dict_cache {
+            let kana_cache_path = Self::kana_trie_cache_path("kana_trie_cache.marisa")?;
+            let dict_cache_path = Self::kana_trie_cache_path("kana_kanji_cache.marisa")?;
+            let needs_rebuild = match (
+                std::fs::metadata(&kana_cache_path).and_then(|m| m.modified()),
+                std::fs::metadata(&dict_cache_path).and_then(|m| m.modified()),
+            ) {
+                (Ok(kana_mt), Ok(dict_mt)) => kana_mt < dict_mt,
+                _ => true,
+            };
+            if !needs_rebuild {
+                match MarisaKanaTrie::load(&kana_cache_path) {
+                    Ok(t) => Arc::new(Mutex::new(t)),
+                    Err(e) => {
+                        info!(
+                            "Failed to load kana_trie cache ({}): {} — rebuilding",
+                            kana_cache_path, e
+                        );
+                        Self::build_kana_trie_cache(&dict, &single_term, &kana_cache_path)?
+                    }
+                }
+            } else {
+                Self::build_kana_trie_cache(&dict, &single_term, &kana_cache_path)?
+            }
+        } else {
+            // cache 無効時は従来通り cedarwood をその場で構築
+            let mut cw = CedarwoodKanaTrie::default();
+            for yomi in dict.yomis() {
+                assert!(!yomi.is_empty());
+                cw.update(yomi.as_str());
+            }
+            for yomi in single_term.yomis() {
+                assert!(!yomi.is_empty());
+                cw.update(yomi.as_str());
+            }
+            Arc::new(Mutex::new(cw))
+        };
+        info!("[startup] kana_trie ready in {:?}", t.elapsed());
 
-        let segmenter = Segmenter::new(vec![
-            Arc::new(Mutex::new(kana_trie)),
-            user_data.lock().unwrap().kana_trie.clone(),
-        ]);
+        let segmenter =
+            Segmenter::new(vec![kana_trie, user_data.lock().unwrap().kana_trie.clone()]);
 
         let graph_builder: GraphBuilder<
             MarisaSystemUnigramLM,
@@ -241,6 +293,30 @@ impl BigramWordViterbiEngineBuilder {
     fn try_load(model_dir: &str, name: &str) -> Result<String> {
         let path = std::path::Path::new(model_dir).join(name);
         Ok(path.to_string_lossy().to_string())
+    }
+
+    /// `~/.cache/akaza/<name>` を返す（cache ディレクトリを作成）。
+    /// dict_cache と同じ XDG 規約に従う。
+    fn kana_trie_cache_path(name: &str) -> Result<String> {
+        let base_dirs = crate::xdg_dirs::BaseDirectories::with_prefix("akaza")
+            .map_err(|e| anyhow::anyhow!("xdg directory: {e}"))?;
+        base_dirs.create_cache_directory("")?;
+        Ok(base_dirs.get_cache_file(name).to_string_lossy().to_string())
+    }
+
+    /// dict + single_term の yomi 集合から MarisaKanaTrie を構築して `path` に保存する。
+    /// 結果を Arc<Mutex<dyn KanaTrie>> として返す。
+    fn build_kana_trie_cache(
+        dict: &MarisaKanaKanjiDict,
+        single_term: &MarisaKanaKanjiDict,
+        path: &str,
+    ) -> Result<Arc<Mutex<dyn KanaTrie>>> {
+        // dict.yomis() を 2 回回さないよう一旦集める。重複は marisa 側で吸収される
+        // が、push_back_str で alloc を抑えるため事前に確保しておく。
+        let mut keys: Vec<String> = dict.yomis();
+        keys.extend(single_term.yomis());
+        let trie = MarisaKanaTrie::build_and_save(keys, path)?;
+        Ok(Arc::new(Mutex::new(trie)))
     }
 }
 

--- a/libakaza/src/kana_trie/marisa_kana_trie.rs
+++ b/libakaza/src/kana_trie/marisa_kana_trie.rs
@@ -7,12 +7,17 @@ use rsmarisa::{Agent, Keyset, Trie};
 
 use crate::kana_trie::base::KanaTrie;
 
-/// marisa-trie ベースの kana_trie。
+/// marisa-trie ベースの kana_trie（システム辞書向け read-only 実装）。
 ///
 /// 用途は `Segmenter` での共通接頭辞探索（読みのセグメント候補列挙）のみ。
 /// 起動時に毎回 cedarwood を 100 万件の `update()` で構築すると 1 秒前後かかるため、
 /// 同じ読み集合から marisa-trie を一度ビルドして cache file に保存し、
 /// 次回以降は load だけで済むようにしている。
+///
+/// なお `UserData::kana_trie` 側 (ユーザー学習用) には引き続き `CedarwoodKanaTrie`
+/// を使っている。marisa-trie は build 後 immutable なので、ユーザーが新語を学習
+/// するたびに動的に entry を追加していくユースケースには使えない。`UserData` の
+/// kana_trie が cedarwood である理由は `user_data.rs` のフィールドコメントを参照。
 pub struct MarisaKanaTrie {
     trie: Trie,
     /// 検索ごとに `Agent::new()` するアロケーションを避けるため再利用する。

--- a/libakaza/src/kana_trie/marisa_kana_trie.rs
+++ b/libakaza/src/kana_trie/marisa_kana_trie.rs
@@ -1,0 +1,117 @@
+use std::cell::RefCell;
+
+use anyhow::Result;
+use log::info;
+
+use rsmarisa::{Agent, Keyset, Trie};
+
+use crate::kana_trie::base::KanaTrie;
+
+/// marisa-trie ベースの kana_trie。
+///
+/// 用途は `Segmenter` での共通接頭辞探索（読みのセグメント候補列挙）のみ。
+/// 起動時に毎回 cedarwood を 100 万件の `update()` で構築すると 1 秒前後かかるため、
+/// 同じ読み集合から marisa-trie を一度ビルドして cache file に保存し、
+/// 次回以降は load だけで済むようにしている。
+pub struct MarisaKanaTrie {
+    trie: Trie,
+    /// 検索ごとに `Agent::new()` するアロケーションを避けるため再利用する。
+    agent: RefCell<Agent>,
+}
+
+impl MarisaKanaTrie {
+    pub fn build_and_save<I, S>(keys: I, path: &str) -> Result<MarisaKanaTrie>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut keyset = Keyset::new();
+        for k in keys {
+            let s = k.as_ref();
+            if s.is_empty() {
+                continue;
+            }
+            keyset.push_back_str(s)?;
+        }
+        let mut trie = Trie::new();
+        trie.build(&mut keyset, 0);
+        trie.save(path)?;
+        info!("Saved kana_trie cache: {}", path);
+        Ok(MarisaKanaTrie {
+            trie,
+            agent: RefCell::new(Agent::new()),
+        })
+    }
+
+    pub fn load(path: &str) -> Result<MarisaKanaTrie> {
+        let mut trie = Trie::new();
+        trie.load(path)?;
+        Ok(MarisaKanaTrie {
+            trie,
+            agent: RefCell::new(Agent::new()),
+        })
+    }
+}
+
+impl KanaTrie for MarisaKanaTrie {
+    fn common_prefix_search(&self, query: &str) -> Vec<String> {
+        // CedarwoodKanaTrie 同様、query の prefix と一致する登録済み読みを全部返す。
+        // marisa の common_prefix_search は呼ぶたびに次のヒットを返す iterator 仕様。
+        let mut agent = self.agent.borrow_mut();
+        agent.set_query_str(query);
+
+        let mut out: Vec<String> = Vec::new();
+        while self.trie.common_prefix_search(&mut agent) {
+            let bytes = agent.key().as_bytes();
+            // UTF-8 として有効。yomi のみを格納しているので tab などは含まれない。
+            match std::str::from_utf8(bytes) {
+                Ok(s) => out.push(s.to_string()),
+                Err(_) => continue,
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn build_and_search() -> Result<()> {
+        let tmp = NamedTempFile::new()?;
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        let trie =
+            MarisaKanaTrie::build_and_save(vec!["わたし", "わた", "わし", "ほげほげ"], &path)?;
+
+        let mut got = trie.common_prefix_search("わたしのきもち");
+        got.sort();
+        assert_eq!(got, vec!["わた".to_string(), "わたし".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn save_load_roundtrip() -> Result<()> {
+        let tmp = NamedTempFile::new()?;
+        let path = tmp.path().to_str().unwrap().to_string();
+
+        MarisaKanaTrie::build_and_save(vec!["abc", "ab", "abcd"], &path)?;
+        let loaded = MarisaKanaTrie::load(&path)?;
+        let mut got = loaded.common_prefix_search("abcde");
+        got.sort();
+        assert_eq!(got, vec!["ab", "abc", "abcd"]);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_input_ignored() -> Result<()> {
+        let tmp = NamedTempFile::new()?;
+        let path = tmp.path().to_str().unwrap().to_string();
+        let trie = MarisaKanaTrie::build_and_save(vec!["abc", ""], &path)?;
+        let got = trie.common_prefix_search("abc");
+        assert_eq!(got, vec!["abc".to_string()]);
+        Ok(())
+    }
+}

--- a/libakaza/src/kana_trie/mod.rs
+++ b/libakaza/src/kana_trie/mod.rs
@@ -4,3 +4,4 @@
  */
 pub mod base;
 pub mod cedarwood_kana_trie;
+pub mod marisa_kana_trie;

--- a/libakaza/src/lm/system_bigram.rs
+++ b/libakaza/src/lm/system_bigram.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read as _, Write as _};
+use std::io::{BufWriter, Read as _, Write as _};
 
 use rustc_hash::FxHashMap;
 
@@ -169,15 +169,27 @@ impl MarisaSystemBigramLM {
     }
 
     fn load_scores(path: &str) -> Result<Vec<f16>> {
-        let mut reader = BufReader::new(File::open(path)?);
+        // 旧実装は 2 バイトずつ read_exact + push する loop だった。
+        // bigram で 18M, skip_bigram で 30M entry あるので syscall/branch のオーバーヘッドが
+        // 起動時間にそのまま乗っていた。Vec<f16> を必要長で確保し、その underlying bytes
+        // に対して 1 回の read_exact で埋める形に変更。
+        let mut file = File::open(path)?;
         let mut buf4 = [0u8; 4];
-        reader.read_exact(&mut buf4)?;
+        file.read_exact(&mut buf4)?;
         let num_entries = u32::from_le_bytes(buf4) as usize;
-        let mut scores = Vec::with_capacity(num_entries);
-        let mut buf2 = [0u8; 2];
-        for _ in 0..num_entries {
-            reader.read_exact(&mut buf2)?;
-            scores.push(f16::from_le_bytes(buf2));
+
+        let mut scores: Vec<f16> = vec![f16::ZERO; num_entries];
+        // SAFETY: f16 は `#[repr(transparent)]` over u16 の Copy 型なので任意ビット列が
+        // 有効。ファイルフォーマットは LE 2 バイト/entry で、x86_64 はリトルエンディアン
+        // のため、underlying バイト列にそのまま read_exact できる。
+        // 他 arch (big endian) でも、半精度の生ビット列を読み込むだけなので未定義動作
+        // にはならない (値の解釈は別問題だが、現状 akaza は LE プラットフォームのみ想定)。
+        let bytes_len = num_entries * std::mem::size_of::<f16>();
+        if bytes_len > 0 {
+            let bytes: &mut [u8] = unsafe {
+                std::slice::from_raw_parts_mut(scores.as_mut_ptr() as *mut u8, bytes_len)
+            };
+            file.read_exact(bytes)?;
         }
         Ok(scores)
     }

--- a/libakaza/src/lm/system_skip_bigram.rs
+++ b/libakaza/src/lm/system_skip_bigram.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read as _, Write as _};
+use std::io::{BufWriter, Read as _, Write as _};
 
 use anyhow::{bail, Result};
 use half::f16;
@@ -172,15 +172,23 @@ impl MarisaSystemSkipBigramLM {
     }
 
     fn load_scores(path: &str) -> Result<Vec<f16>> {
-        let mut reader = BufReader::new(File::open(path)?);
+        // 旧実装は 2 バイトずつ read_exact + push する loop だった (system_bigram と同様)。
+        // skip_bigram は 30M entry あり、起動時間に大きく寄与していたため一括 read に変更。
+        let mut file = File::open(path)?;
         let mut buf4 = [0u8; 4];
-        reader.read_exact(&mut buf4)?;
+        file.read_exact(&mut buf4)?;
         let num_entries = u32::from_le_bytes(buf4) as usize;
-        let mut scores = Vec::with_capacity(num_entries);
-        let mut buf2 = [0u8; 2];
-        for _ in 0..num_entries {
-            reader.read_exact(&mut buf2)?;
-            scores.push(f16::from_le_bytes(buf2));
+
+        let mut scores: Vec<f16> = vec![f16::ZERO; num_entries];
+        // SAFETY: f16 は `#[repr(transparent)]` over u16 の Copy 型なので任意ビット列が
+        // 有効。ファイルフォーマットは LE 2 バイト/entry で、x86_64 はリトルエンディアン
+        // のため、underlying バイト列にそのまま read_exact できる。
+        let bytes_len = num_entries * std::mem::size_of::<f16>();
+        if bytes_len > 0 {
+            let bytes: &mut [u8] = unsafe {
+                std::slice::from_raw_parts_mut(scores.as_mut_ptr() as *mut u8, bytes_len)
+            };
+            file.read_exact(bytes)?;
         }
         Ok(scores)
     }

--- a/libakaza/src/user_side_data/user_data.rs
+++ b/libakaza/src/user_side_data/user_data.rs
@@ -26,9 +26,14 @@ use crate::user_side_data::user_stats_utils::{
 #[derive(Default)]
 pub struct UserData {
     /// 読み仮名のトライ。入力変換時に共通接頭辞検索するために使用。
-    // ここで MARISA ではなく Cedarwood を採用しているのは
-    // - FFI していると std::marker::Send を実装できなくてスレッドをまたいだ処理が困難になるから
-    // - 更新可能なトライ構造だから
+    // ここで marisa-trie ではなく Cedarwood を採用しているのは、ユーザーが
+    // 確定するたびに `update()` で新しい読みを追加していくユースケースだから。
+    // marisa-trie は build 後 immutable なので向かない。
+    //
+    // 過去には「FFI していると std::marker::Send を実装できなくてスレッドを
+    // またいだ処理が困難」という理由もあったが、rsmarisa (pure Rust 移植) は
+    // `Trie`/`Agent` ともに Send なのでこの懸念は解消済み。なお system 辞書側の
+    // read-only kana_trie は MarisaKanaTrie に置き換え済み (起動時間短縮)。
     pub(crate) kana_trie: Arc<Mutex<CedarwoodKanaTrie>>,
 
     unigram_user_stats: UniGramUserStats,


### PR DESCRIPTION
## Summary

エンジン起動時間 (`BigramWordViterbiEngineBuilder::build`) を、kana_trie の cache 化と `.scores` の一括 read で大幅に短縮しました。あわせて rsmarisa を 0.4.2 に更新し、PR #21 の trie lookup ホットパス最適化なども取り込んでいます。

### 起動時間の内訳

| 段階 | 元 (cache hit) | 改善後 cold | 改善後 warm |
|---|---|---|---|
| unigram.model load | 7ms | 11ms | 7ms |
| bigram.model + scores load | 154ms | 59ms | 32ms |
| skip_bigram.model + scores load | 254ms | 94ms | 56ms |
| dict load (cache hit) | 7ms | 12-20ms | 6ms |
| **kana_trie 構築** | **1069ms** | **3ms** | **1.7ms** |
| **合計 (Engine built)** | **1490ms** | **~200ms** | **~100ms** |

cold は `posix_fadvise(POSIX_FADV_DONTNEED)` で当該ファイルを page cache から追い出した状態。

cache 無効時の元値は約 **7 秒** で、初回 IBus 起動時に体感できるレベルの遅さでした。

## 変更内容

### 1. rsmarisa を 0.4.0 → 0.4.2 に更新

- PR #21 で取り込まれた trie lookup ホットパス最適化 (PDEP-based select、Vec alloc 撤去、Cache ローカルコピー)
- PR #23 の bit-vector word size 統一など

### 2. kana_trie を marisa-trie ベースに変更し cache 化

最大の起動コストだった `CedarwoodKanaTrie` の毎起動構築 (約 1 秒) を、marisa-trie として `~/.cache/akaza/kana_trie_cache.marisa` に永続化することで `Trie::load` (~ms) に置き換え。

- `libakaza/src/kana_trie/marisa_kana_trie.rs` を追加 (`KanaTrie` trait 実装)
- 鮮度判定は `kana_kanji_cache.marisa` の mtime と同期
- `dict_cache=false` の場合は従来の cedarwood 経路にフォールバック
- engine builder 内に `info!("[startup] ...")` を入れてロード段階別のタイミングが見えるようにした

### 3. `.scores` ファイルを一括 read

bigram (18M entry) / skip_bigram (30M entry) の `.scores` を 2 バイトずつ `read_exact` する loop で読んでいたのを、`Vec<f16>` の underlying byte slice に 1 回の `read_exact` で埋める形に変更。`f16` は `#[repr(transparent)] u16` で LE プラットフォーム上はそのまま reinterpret 可。

### 4. bench を拡張

起動時間チューニング用に `bench` コマンドを拡張:

- `--dict-cache` フラグ (default off): cache hit 時の起動時間を計測したい時に opt-in
- 最長文を 5 回連続で convert する cold/warm probe
- 最初の sentence の per-call ms

## テスト結果

- `cargo test --release --lib -p libakaza`: **133 passed** ✅
- `cargo build --release -p akaza-data` ✅
- `akaza-data check --model-dir default-model/data "わたしのなまえはなかのです"` → `私/の/名前/は/中野/です` ✅
- bench (30 sentences, cold cache, dict_cache=on): `Engine built in 203ms`, avg=6.1ms / median=4.1ms (変換速度は退行なし)

## 設計上のトレードオフ

- **真の zero-copy mmap は採用しなかった**。rsmarisa の現状の `Trie::mmap()` は内部で `Vec` にコピーするため効果が限定的で、本格的な zero-copy 化には rsmarisa の `Vector<T>` を「所有 / mmap 借用」の enum に作り変える必要があるため。今回の方針 (kana_trie cache + scores fast read) で 500ms 目標を満たせたので見送り
- **scores の `unsafe` は LE プラットフォーム前提**。BE arch をサポートする必要が出たら portable な `chunks_exact + from_le_bytes` 経路に切り替える

## 残りの改善余地

- skip_bigram の model + scores を std::thread で並列ロードすると 50-100ms 削れる見込み
- skip_bigram_weight=0 のときに skip_bigram の load 自体を skip する lazy load