### PR TITLE
fix: 変換ごとに呼ばれる info ログを debug レベルに変更

### DIFF
--- a/libakaza/src/dict/loader.rs
+++ b/libakaza/src/dict/loader.rs
@@ -6,7 +6,7 @@ use std::time::SystemTime;
 use anyhow::Context;
 use anyhow::Result;
 use encoding_rs::{EUC_JP, UTF_8};
-use log::{error, info};
+use log::{debug, error, info};
 
 use crate::config::{DictConfig, DictEncoding, DictType};
 use crate::dict::merge_dict::merge_dict;
@@ -33,7 +33,7 @@ pub fn load_dicts_with_cache(
         .iter()
         .map(|it| try_get_mtime(&it.path).unwrap_or(0_u128))
         .collect::<Vec<_>>();
-    info!("mtimes: {:?}", p);
+    debug!("mtimes: {:?}", p);
 
     let max_dict_mtime = dict_configs
         .iter()
@@ -53,7 +53,7 @@ pub fn load_dicts_with_cache(
 
     // 現在の Config をシリアライズする。
     let config_serialized = serde_yaml::to_string(dict_configs)?;
-    info!("SERIALIZED: {:?}", config_serialized);
+    debug!("SERIALIZED: {:?}", config_serialized);
 
     if cache_mtime >= max_dict_mtime {
         match MarisaKanaKanjiDict::load(cache_path.as_str()) {
@@ -62,7 +62,7 @@ pub fn load_dicts_with_cache(
                 if dict_serialized == config_serialized {
                     // キャッシュファイルを書いた時の設定と同じかどうかを確認する
                     // 設定が違う場合は、キャッシュを作り直す必要がある。
-                    info!("Cache is fresh! {:?} => {}", dict_configs, cache_path);
+                    debug!("Cache is fresh! {:?} => {}", dict_configs, cache_path);
                     return Ok(dict);
                 } else {
                     info!(

--- a/libakaza/src/extend_clause.rs
+++ b/libakaza/src/extend_clause.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::debug;
 use std::ops::Range;
 
 use crate::graph::candidate::Candidate;
@@ -22,13 +22,13 @@ pub fn extend_right(clauses: &[Vec<Candidate>], current_clause: usize) -> Vec<Ra
         return Vec::new();
     }
     // 一番右の文節が選択されていたらなにもできない。
-    info!(
+    debug!(
         "Keep current? current={:?} len={}",
         current_clause,
         clauses.len()
     );
     if current_clause == clauses.len() - 1 {
-        info!("Keep current");
+        debug!("Keep current");
         return keep_current(clauses);
     }
 

--- a/libakaza/src/graph/graph_resolver.rs
+++ b/libakaza/src/graph/graph_resolver.rs
@@ -5,7 +5,9 @@ use std::rc::Rc;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use anyhow::{bail, Context};
-use log::{error, info, trace};
+use log::{debug, error, trace};
+#[cfg(test)]
+use log::info;
 
 use crate::graph::candidate::Candidate;
 use crate::graph::lattice_graph::LatticeGraph;
@@ -466,7 +468,7 @@ impl GraphResolver {
     ) {
         if depth > 4 {
             // depth が深過ぎたら諦める。
-            info!(
+            debug!(
                 "collect_splited_results: too deep: node_yomi={:?}, cur_surface={:?}",
                 node_yomi, cur_surface
             );

--- a/libakaza/src/graph/graph_resolver.rs
+++ b/libakaza/src/graph/graph_resolver.rs
@@ -5,9 +5,9 @@ use std::rc::Rc;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use anyhow::{bail, Context};
-use log::{debug, error, trace};
 #[cfg(test)]
 use log::info;
+use log::{debug, error, trace};
 
 use crate::graph::candidate::Candidate;
 use crate::graph::lattice_graph::LatticeGraph;

--- a/libakaza/src/graph/lattice_graph.rs
+++ b/libakaza/src/graph/lattice_graph.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use log::{error, info, trace};
+use log::{debug, error, trace};
 
 use crate::graph::word_node::WordNode;
 use crate::lm::base::{SystemBigramLM, SystemUnigramLM};
@@ -136,7 +136,7 @@ impl<U: SystemUnigramLM, B: SystemBigramLM> LatticeGraph<U, B> {
         user_data: &UserData,
     ) -> f32 {
         if let Some(user_cost) = user_data.get_unigram_cost(node) {
-            info!("Use user's node score: {:?}", node);
+            debug!("Use user's node score: {:?}", node);
             // use user's score. if it's exists.
             return user_cost;
         }


### PR DESCRIPTION
## Summary

変換の都度呼ばれる `info!` ログを `debug!` に変更する。

### 変更箇所

| ファイル | ログメッセージ | 問題 |
|---|---|---|
| `lattice_graph.rs` | `"Use user's node score: {:?}"` | **変換ごと・全ノード分呼ばれる**（最大の問題） |
| `extend_clause.rs` | `"Keep current? ..."` / `"Keep current"` | 文節伸縮ごとに呼ばれる |
| `graph_resolver.rs` | `"collect_splited_results: too deep"` | k-best 探索中の再帰ごと |
| `dict/loader.rs` | `mtimes`, `SERIALIZED`, `"Cache is fresh!"` | 内部実装詳細 |

### 背景

mac-akaza 環境で `~/Library/Logs/AkazaIME/akaza.log` が 2.2 GB に肥大化し、macOS のディスク書き込み制限（約 2147 MB/86400s/プロセス）に抵触して変換が停止する問題が発生した。原因の大部分が `lattice_graph` の `"Use user's node score"` メッセージ（1キーストロークで数十行出力）だった。

起動時・モデルロード時の `info!` ログはそのまま。`RUST_LOG=debug` で従来通り全ログを確認できる。